### PR TITLE
Removing adjusted Freewheel bidder code.

### DIFF
--- a/README_Maven.md
+++ b/README_Maven.md
@@ -1,0 +1,27 @@
+This is a fork of the [Prebid.js repository](https://github.com/prebid/Prebid.js).
+
+Changes unique to this fork:
+
+* This file (README\_Maven.md)
+* Module configuration for the Salish platform (modules.json)
+* Module configuration for the HubPages platform (hpmodules.json)
+* The Sublime bid adapter module (modules/sublimeBidAdapter.js)
+  and tests (test/spec/modules/sublimeBidAdapter\_spec.js)
+
+
+## Building the Salish Prebid Bundle
+
+Follow the README.md instructions for setting up this repository, then use this
+command to build the bundle:
+
+    $ gulp build --modules=modules.json
+
+You'll find the built prebid.js file in build/dist/prebid.js.
+
+
+## Building the HubPages Prebid Bundle
+
+    $ gulp build --modules=hpmodules.json
+
+You'll find the built prebid.js file in build/dist/prebid.js.
+

--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -2,7 +2,7 @@ import * as utils from '../src/utils';
 import { registerBidder } from '../src/adapters/bidderFactory';
 // import { config } from '../src/config';
 
-const BIDDER_CODE = 'freewheel';
+const BIDDER_CODE = 'freewheel-ssp';
 
 const PROTOCOL = getProtocol();
 const FREEWHEEL_ADSSETUP = PROTOCOL + '://ads.stickyadstv.com/www/delivery/swfIndex.php';


### PR DESCRIPTION
Now using 'freewheel-ssp' instead of 'freewheel'.

Also created a README file to document other files in the repo that are
unique to this fork.

ADS-3449
