### PR TITLE
ADS-3448 Add browser type to Hummingbird data

### DIFF
--- a/modules/mavenAnalyticsAdapter.js
+++ b/modules/mavenAnalyticsAdapter.js
@@ -210,24 +210,27 @@ mavenAnalytics.enableAnalytics = function (config) {
 mavenAnalytics.generateBrowserType = function() {
     // Browser sniffing -- this gets us all browser families with >1% of
     // traffic, according to the 2019 Wikimedia report.
+    //
+    // We can't use String.prototype.includes to allow support of IE.
     let ua = navigator.userAgent;
-    if (ua.includes('Chrome/')) {
-        if (ua.includes('Edg/') || ua.includes('Edge')) {
+    if (ua.indexOf('Chrome/') >= 0) {
+        if (ua.indexOf('Edg/') >= 0 || ua.indexOf('Edge') >= 0) {
             return 'edge';
-        } else if (ua.includes('SamsungBrowser')) {
+        } else if (ua.indexOf('SamsungBrowser') >= 0) {
             return 'samsung';
-        } else if (!ua.includes('Chromium/')) {
+        } else if (ua.indexOf('Chromium/') == -1) {
+            // Chromium could be Chromium, Brave, etc.
             return 'chrome';
         }
-    } else if (ua.includes('Safari/')) {
+    } else if (ua.indexOf('Safari/') >= 0) {
         return 'safari';
-    } else if (ua.includes('Firefox/')) {
-        if (!ua.includes('Seamonkey/')) {
+    } else if (ua.indexOf('Firefox/') >= 0) {
+        if (ua.indexOf('Seamonkey/') == -1) {
             return 'firefox';
         }
-    } else if (ua.includes('Trident/') || ua.includes('MSIE')) {
+    } else if (ua.indexOf('Trident/') >= 0 || ua.indexOf('MSIE') >= 0) {
         return 'ie';
-    } else if (ua.includes('OPR/') || ua.includes('Opera/')) {
+    } else if (ua.indexOf('OPR/') >= 0 || ua.indexOf('Opera/') >= 0) {
         return 'opera';
     }
     return 'other';

--- a/modules/mavenAnalyticsAdapter.js
+++ b/modules/mavenAnalyticsAdapter.js
@@ -209,7 +209,10 @@ mavenAnalytics.enableAnalytics = function (config) {
 
 mavenAnalytics.generateBrowserType = function() {
     // Browser sniffing -- this gets us all browser families with >1% of
-    // traffic, according to the 2019 Wikimedia report.
+    // traffic, according to the 2019 Wikimedia report. This set of tests
+    // is largely based on
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+    // and should be relatively resilient to changes in user-agent behavior.
     //
     // We can't use String.prototype.includes to allow support of IE.
     let ua = navigator.userAgent;

--- a/modules/mavenAnalyticsAdapter.js
+++ b/modules/mavenAnalyticsAdapter.js
@@ -217,7 +217,9 @@ mavenAnalytics.generateBrowserType = function() {
     // We can't use String.prototype.includes to allow support of IE.
     let ua = navigator.userAgent;
     if (ua.indexOf('Chrome/') >= 0) {
-        if (ua.indexOf('Edg/') >= 0 || ua.indexOf('Edge') >= 0) {
+        if (ua.indexOf('OPR/') >= 0) {
+            return 'opera';
+        } else if (ua.indexOf('Edg/') >= 0 || ua.indexOf('Edge') >= 0) {
             return 'edge';
         } else if (ua.indexOf('SamsungBrowser') >= 0) {
             return 'samsung';

--- a/modules/mavenAnalyticsAdapter.js
+++ b/modules/mavenAnalyticsAdapter.js
@@ -55,6 +55,7 @@ let mavenAnalytics = Object.assign(adapter({hummingbirdUrl, analyticsType}), {
                     }
                     auctionObj = {
                         auctionId: id,
+                        browserType: options.browserType,
                         connectionEffectiveType: connType,
                         contentItemId: options.contentItemId,
                         correlator: window.hummingbirdCorrelator,
@@ -199,11 +200,38 @@ mavenAnalytics.enableAnalytics = function (config) {
         return;
     }
     options = config.options;
+    options.browserType = this.generateBrowserType();
     mavenAnalytics.originEnableAnalytics(config); // call the base class function
     initialized = true;
     hummingbirdUrl = options.url; 
     verbose = !!options.verbose;
 };
+
+mavenAnalytics.generateBrowserType = function() {
+    // Browser sniffing -- this gets us all browser families with >1% of
+    // traffic, according to the 2019 Wikimedia report.
+    let ua = navigator.userAgent;
+    if (ua.includes('Chrome/')) {
+        if (ua.includes('Edg/') || ua.includes('Edge')) {
+            return 'edge';
+        } else if (ua.includes('SamsungBrowser')) {
+            return 'samsung';
+        } else if (!ua.includes('Chromium/')) {
+            return 'chrome';
+        }
+    } else if (ua.includes('Safari/')) {
+        return 'safari';
+    } else if (ua.includes('Firefox/')) {
+        if (!ua.includes('Seamonkey/')) {
+            return 'firefox';
+        }
+    } else if (ua.includes('Trident/') || ua.includes('MSIE')) {
+        return 'ie';
+    } else if (ua.includes('OPR/') || ua.includes('Opera/')) {
+        return 'opera';
+    }
+    return 'other';
+}
 
 adaptermanager.registerAnalyticsAdapter({
     adapter: mavenAnalytics,


### PR DESCRIPTION
This changeset adds very simple user-agent sniffing to classify
visits into a limited number of browser-family buckets, giving us
a little more insight into bidding trends.