### PR TITLE
Update to determine connectionEffectiveType property

### DIFF
--- a/modules/mavenAnalyticsAdapter.js
+++ b/modules/mavenAnalyticsAdapter.js
@@ -26,9 +26,11 @@ let currentBatch = [],
     connectionEffectiveType;
 
 if (navigator.connection) {
-    navigator.connection.addEventListener('change', function() {
+    const setConnectionEffectiveType = function() {
         connectionEffectiveType = navigator.connection.effectiveType;
-    });
+    };
+    navigator.connection.addEventListener('change', setConnectionEffectiveType);
+    setConnectionEffectiveType();
 }
 
 let mavenAnalytics = Object.assign(adapter({hummingbirdUrl, analyticsType}), {


### PR DESCRIPTION
Uses an event hook to signal assignment of the property instead of
assuming the value is ready (also causes it to update itself if
connection rate changes between auctions).

Sends 'other' as the value for connectionEffectiveType if the
connection type cannot be determined (likely due to browser
limitations).

ADS-3976
