### PR TITLE
ADS-4131 Add LiftIgniterAnalyticsAdapter

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -1,0 +1,181 @@
+'use strict';
+// LiftIgniter or Petametrics
+
+import CONSTANTS from '../src/constants.json';
+import adaptermanager from '../src/adapterManager.js';
+import adapter from '../src/AnalyticsAdapter.js';
+import { logError } from '../src/utils.js';
+
+// Standard Analytics Adapter code
+const AUCTION_END = CONSTANTS.EVENTS.AUCTION_END
+
+// Internal controls
+const BATCH_MESSAGE_FREQUENCY = 1000; // Send results batched on a 1s delay
+
+const PROVIDER_CODE = 'mavenDistributionAnalyticsAdapter'
+const MAVEN_DISTRIBUTION_GLOBAL = '$p'
+
+/**
+ * We may add more fields in the future
+ * @typedef {{
+ *  provider: typeof PROVIDER_CODE
+ *  options: {
+ *     sampling?: number
+ *     zoneMap: {[adUnitCode: string]: {index?: number, zone?: string}}
+ *  }
+ * }} MavenDistributionAdapterConfig
+ */
+
+/**
+ * import {AUCTION_STARTED, AUCTION_IN_PROGRESS, AUCTION_COMPLETED} from '../src/auction';
+ * @typedef {{
+ *   auctionId: string
+ *   timestamp: Date
+ *   auctionEnd: Date
+ *   auctionStatus: typeof AUCTION_STARTED | typeof AUCTION_IN_PROGRESS | typeof AUCTION_COMPLETED
+ *   adUnits: any[]
+ *   adUnitCodes: any[]
+ *   labels: any[]
+ *   bidderRequests: any[]
+ *   noBids: any[]
+ *   bidsReceived: any[]
+ *   winningBids: any[]
+ *   timeout: number
+ * }} AuctionEventArgs
+ */
+
+/**
+ * // cpms, zoneIndexes, and zoneNames all have the same length
+ * @typedef {{
+ *   auc: string
+ *   cpms: number[]
+ *   zoneIndexes: number[]
+ *   zoneNames: string[]
+ * }} AuctionEndSummary
+ */
+
+/**
+ * @param {AuctionEventArgs} args
+ * @param {MavenDistributionAdapterConfig} adapterConfig
+ * @return {AuctionEndSummary}
+ */
+export function summarizeAuctionEnd(args, adapterConfig) {
+  /** @type {{[code: string]: number}} */
+  const cpmsMap = {}
+  const zoneNames = []
+  const zoneIndexes = []
+  args.adUnits.forEach(adUnit => {
+    cpmsMap[adUnit.code] = 0
+    const zoneConfig = adapterConfig.options.zoneMap[adUnit.code] || {}
+    let zoneIndex = zoneConfig.index != null && isFinite(zoneConfig.index)
+      ? +zoneConfig.index : null
+    zoneIndexes.push(zoneIndex)
+    zoneNames.push(zoneConfig.zone != null ? zoneConfig.zone : null)
+  })
+  args.bidsReceived.forEach(bid => {
+    cpmsMap[bid.adUnitCode] = Math.max(cpmsMap[bid.adUnitCode], bid.cpm || 0)
+  })
+  const cpms = args.adUnits.map(adUnit => cpmsMap[adUnit.code])
+
+  /** @type {AuctionEndSummary} */
+  const eventToSend = {
+    auc: args.auctionId,
+    cpms: cpms,
+    zoneIndexes: zoneIndexes,
+    zoneNames: zoneNames,
+  }
+  return eventToSend
+}
+
+/**
+ * @param {AuctionEndSummary[]} batch
+ * @return {{batch: string}}
+ */
+export function createSendOptionsFromBatch(batch) {
+  const batchJson = JSON.stringify(batch)
+  return { batch: batchJson }
+}
+
+/**
+ * @param {MavenDistributionAdapterConfig} adapterConfig
+ * @property {object[] | null} batch
+ * @property {number | null} batchTimeout
+ * @property {MavenDistributionAdapterConfig} adapterConfig
+ */
+function MavenDistributionAnalyticsAdapterInner(adapterConfig) {
+  this.batch = null
+  this.batchTimeout = null
+  this.adapterConfig = adapterConfig
+}
+MavenDistributionAnalyticsAdapterInner.prototype = {
+  /**
+   * @param {{eventType: string, args: any}} typeAndArgs
+   */
+  track(typeAndArgs) {
+    const {eventType, args} = typeAndArgs
+    if (eventType === AUCTION_END) {
+      const eventToSend = summarizeAuctionEnd(args, this.adapterConfig)
+      if (!this.batch) {
+        this.batch = []
+        this.timeout = setTimeout(this._sendBatch.bind(this), BATCH_MESSAGE_FREQUENCY)
+      }
+      this.batch.push(eventToSend)
+    }
+  },
+
+  _sendBatch() {
+    const sendOptions = createSendOptionsFromBatch(this.batch)
+    if (window[MAVEN_DISTRIBUTION_GLOBAL]) {
+      window[MAVEN_DISTRIBUTION_GLOBAL]('send', 'prebid', sendOptions)
+      this.timeout = null
+      this.batch = null
+    } else {
+      this.timeout = setTimeout(this._sendBatch.bind(this), BATCH_MESSAGE_FREQUENCY)
+    }
+  },
+}
+
+/**
+ * @property {MavenDistributionAnalyticsAdapterInner | null} inner
+ * @property {AnalyticsAdapter | null} adapter
+ */
+function MavenDistributionAnalyticsAdapter() {
+  this.base = null
+  this.inner = null
+}
+MavenDistributionAnalyticsAdapter.prototype = {
+  /**
+   * @param {MavenDistributionAdapterConfig} adapterConfig
+   * @returns {void}
+   */
+  enableAnalytics(adapterConfig) {
+    if (this.base != null) {
+      // call base implementation which prints a warning
+      return this.base.enableAnalytics(adapterConfig)
+    }
+    if (adapterConfig.options.zoneMap == null) {
+      return logError(`Adapter ${PROVIDER_CODE}: zoneMap null; disabling`)
+    }
+    const inner = new MavenDistributionAnalyticsAdapterInner(adapterConfig)
+    const base = adapter({global: MAVEN_DISTRIBUTION_GLOBAL})
+    base.track = inner.track.bind(inner)
+    base.enableAnalytics(adapterConfig)
+    this.inner = inner
+    this.base = base
+  },
+  disableAnalytics() {
+    if (this.base != null) {
+      this.base.disableAnalytics()
+      this.base = null
+      this.inner = null
+    }
+  }
+}
+
+const mavenDistributionAnalyticsAdapter = new MavenDistributionAnalyticsAdapter()
+adaptermanager.registerAnalyticsAdapter({
+  adapter: mavenDistributionAnalyticsAdapter,
+  code: PROVIDER_CODE,
+});
+
+export default mavenDistributionAnalyticsAdapter;

--- a/modules/mavenDistributionAnalyticsAdapter.md
+++ b/modules/mavenDistributionAnalyticsAdapter.md
@@ -1,0 +1,25 @@
+# Overview
+
+Module Name: MavenDistribution Analytics Adapter
+Module Type: Analytics Adapter
+Maintainer: yonathan.randolph@maven.io
+
+# Description
+
+Reports ad bids to MavenDistribution (aka Petametrics or LiftIgniter).
+
+# Configuration
+
+`zoneMap` is expected to be a map of `adUnit.code` to `{index, zone}`.
+
+```
+pbjs.enableAnalytics({
+  provider: 'mavenDistributionAnalyticsAdapter',
+  options: {
+    sampling: 1,
+    zoneMap: {
+      "ad-123456": {"index": 0, "zone": "sidemap"},
+    }
+  },
+});
+```

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -1,0 +1,817 @@
+import { createSendOptionsFromBatch, summarizeAuctionEnd } from '../../../modules/mavenDistributionAnalyticsAdapter.js';
+
+var assert = require('assert');
+
+describe('MavenDistributionAnalyticsAdapter', function () {
+  describe('summarizeAuctionEnd', function () {
+    it('should summarize', () => {
+      const args = {
+        'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+        'timestamp': 1592017351705,
+        'auctionEnd': 1592017352034,
+        'auctionStatus': 'completed',
+        'adUnits': [
+          {
+            'code': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'adUnitPath': '/88059007/www.si.com/homepage',
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'bids': [
+              {
+                'bidder': 'ix',
+                'params': {
+                  'siteId': '414960',
+                  'id': 'www.si.com_fixed_bottom_0_dt',
+                  'size': [
+                    728,
+                    90
+                  ]
+                }
+              },
+              {
+                'bidder': 'rubicon',
+                'params': {
+                  'accountId': '10348',
+                  'floor': 0.1,
+                  'siteId': '283708',
+                  'zoneId': '1419652',
+                  'inventory': {
+                    'au1': [
+                      'sportsillustrated.192.168.1.9.xip.io'
+                    ],
+                    'pod': [
+                      '13'
+                    ]
+                  }
+                }
+              },
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'allowSmallerSizes': true,
+                  'reserve': 0.1,
+                  'invCode': 'www.si.com_fixed_bottom_0_dt',
+                  'member': '8186',
+                  'keywords': {
+                    'cm': 'tempest',
+                    'adzone': 'fixed_bottom',
+                    'index': 0,
+                    'adzoneindex': 'fixed_bottom_0',
+                    'siteadzoneindex': 'www.si.com_fixed_bottom_0',
+                    'path': '/',
+                    'pagetype': 'homepage',
+                    'cv': 'sports',
+                    'au1': 'sportsillustrated.192.168.1.9.xip.io',
+                    'pod': 13
+                  }
+                }
+              },
+              {
+                'bidder': 'pubmatic',
+                'params': {
+                  'adSlot': 'www.si.com_fixed_bottom_0_dt@728x90',
+                  'kadfloor': '0.10',
+                  'pmzoneid': 'www.si.com',
+                  'publisherId': '156229',
+                  'dctr': 'au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13'
+                }
+              },
+              {
+                'bidder': 'sovrn',
+                'params': {
+                  'bidfloor': '0.10',
+                  'tagid': '644735'
+                }
+              },
+              {
+                'bidder': 'sortable',
+                'params': {
+                  'floor': 0.1,
+                  'siteId': 'www.si.com',
+                  'tagId': 'fixed_bottom'
+                }
+              },
+              {
+                'bidder': '33across',
+                'params': {
+                  'siteId': 'b1EXDC3VKr6yoEaKkGJozW',
+                  'productId': 'siab'
+                }
+              }
+            ],
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8'
+          }
+        ],
+        'adUnitCodes': [
+          'ad-42a6e2ce42724767a2288295baa68f98'
+        ],
+        'bidderRequests': [
+          {
+            'bidderCode': 'ix',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '439661490c5b7a68',
+            'bids': [
+              {
+                'bidder': 'ix',
+                'params': {
+                  'siteId': '414960',
+                  'id': 'www.si.com_fixed_bottom_0_dt',
+                  'size': [
+                    728,
+                    90
+                  ]
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '4467d6e5a16adcd',
+                'bidderRequestId': '439661490c5b7a68',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351708
+          },
+          {
+            'bidderCode': 'rubicon',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '4559774772c7f83',
+            'bids': [
+              {
+                'bidder': 'rubicon',
+                'params': {
+                  'accountId': 10348,
+                  'floor': 0.1,
+                  'siteId': 283708,
+                  'zoneId': 1419652,
+                  'inventory': {
+                    'au1': [
+                      'sportsillustrated.192.168.1.9.xip.io'
+                    ],
+                    'pod': [
+                      '13'
+                    ]
+                  }
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '46e15874aa78708',
+                'bidderRequestId': '4559774772c7f83',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0,
+                'startTime': 1592017351709
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351709
+          },
+          {
+            'bidderCode': 'appnexus',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '47501ed0d7e43e1',
+            'bids': [
+              {
+                'bidder': 'appnexus',
+                'params': {
+                  'allowSmallerSizes': true,
+                  'reserve': 0.1,
+                  'invCode': 'www.si.com_fixed_bottom_0_dt',
+                  'member': '8186',
+                  'keywords': {
+                    'cm': 'tempest',
+                    'adzone': 'fixed_bottom',
+                    'index': 0,
+                    'adzoneindex': 'fixed_bottom_0',
+                    'siteadzoneindex': 'www.si.com_fixed_bottom_0',
+                    'path': '/',
+                    'pagetype': 'homepage',
+                    'cv': 'sports',
+                    'au1': 'sportsillustrated.192.168.1.9.xip.io',
+                    'pod': 13
+                  }
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '48fb5e592b951c58',
+                'bidderRequestId': '47501ed0d7e43e1',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351711
+          },
+          {
+            'bidderCode': 'pubmatic',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '493dcc5df87dc62',
+            'bids': [
+              {
+                'bidder': 'pubmatic',
+                'params': {
+                  'adSlot': 'www.si.com_fixed_bottom_0_dt@728x90',
+                  'kadfloor': '0.10',
+                  'pmzoneid': 'www.si.com',
+                  'publisherId': '156229',
+                  'dctr': 'au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13'
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '509d5df6b893fec8',
+                'bidderRequestId': '493dcc5df87dc62',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351713
+          },
+          {
+            'bidderCode': 'sovrn',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '515f49911de95af8',
+            'bids': [
+              {
+                'bidder': 'sovrn',
+                'params': {
+                  'bidfloor': '0.10',
+                  'tagid': '644735'
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '521c419177add6c',
+                'bidderRequestId': '515f49911de95af8',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351714
+          },
+          {
+            'bidderCode': 'sortable',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '532f224df645cff',
+            'bids': [
+              {
+                'bidder': 'sortable',
+                'params': {
+                  'floor': 0.1,
+                  'siteId': 'www.si.com',
+                  'tagId': 'fixed_bottom'
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '54da9bcd0e6e58f8',
+                'bidderRequestId': '532f224df645cff',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351715
+          },
+          {
+            'bidderCode': '33across',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'bidderRequestId': '55ad30c776f479c8',
+            'bids': [
+              {
+                'bidder': '33across',
+                'params': {
+                  'siteId': 'b1EXDC3VKr6yoEaKkGJozW',
+                  'productId': 'siab'
+                },
+                'mediaTypes': {
+                  'banner': {
+                    'sizes': [
+                      [
+                        728,
+                        90
+                      ]
+                    ]
+                  }
+                },
+                'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+                'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ],
+                'bidId': '565b58c654c298c',
+                'bidderRequestId': '55ad30c776f479c8',
+                'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+                'src': 'client',
+                'bidRequestsCount': 3,
+                'bidderRequestsCount': 3,
+                'bidderWinsCount': 0
+              }
+            ],
+            'auctionStart': 1592017351705,
+            'timeout': 27000,
+            'refererInfo': {
+              'referer': 'http://sportsillustrated.192.168.1.9.xip.io:9000/',
+              'reachedTop': true,
+              'numIframes': 0,
+              'stack': [
+                'http://sportsillustrated.192.168.1.9.xip.io:9000/'
+              ],
+              'canonicalUrl': 'https://www.si.com/'
+            },
+            'start': 1592017351716
+          }
+        ],
+        'noBids': [
+          {
+            'bidder': 'sovrn',
+            'params': {
+              'bidfloor': '0.10',
+              'tagid': '644735'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '521c419177add6c',
+            'bidderRequestId': '515f49911de95af8',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': 'sortable',
+            'params': {
+              'floor': 0.1,
+              'siteId': 'www.si.com',
+              'tagId': 'fixed_bottom'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '54da9bcd0e6e58f8',
+            'bidderRequestId': '532f224df645cff',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': 'pubmatic',
+            'params': {
+              'adSlot': 'www.si.com_fixed_bottom_0_dt@728x90',
+              'kadfloor': '0.10',
+              'pmzoneid': 'www.si.com',
+              'publisherId': '156229',
+              'dctr': 'au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13|au1=sportsillustrated.192.168.1.9.xip.io|pod=13'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '509d5df6b893fec8',
+            'bidderRequestId': '493dcc5df87dc62',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': 'appnexus',
+            'params': {
+              'allowSmallerSizes': true,
+              'reserve': 0.1,
+              'invCode': 'www.si.com_fixed_bottom_0_dt',
+              'member': '8186',
+              'keywords': {
+                'cm': 'tempest',
+                'adzone': 'fixed_bottom',
+                'index': 0,
+                'adzoneindex': 'fixed_bottom_0',
+                'siteadzoneindex': 'www.si.com_fixed_bottom_0',
+                'path': '/',
+                'pagetype': 'homepage',
+                'cv': 'sports',
+                'au1': 'sportsillustrated.192.168.1.9.xip.io',
+                'pod': 13
+              }
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '48fb5e592b951c58',
+            'bidderRequestId': '47501ed0d7e43e1',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': '33across',
+            'params': {
+              'siteId': 'b1EXDC3VKr6yoEaKkGJozW',
+              'productId': 'siab'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '565b58c654c298c',
+            'bidderRequestId': '55ad30c776f479c8',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': 'ix',
+            'params': {
+              'siteId': '414960',
+              'id': 'www.si.com_fixed_bottom_0_dt',
+              'size': [
+                728,
+                90
+              ]
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '4467d6e5a16adcd',
+            'bidderRequestId': '439661490c5b7a68',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0
+          },
+          {
+            'bidder': 'rubicon',
+            'params': {
+              'accountId': 10348,
+              'floor': 0.1,
+              'siteId': 283708,
+              'zoneId': 1419652,
+              'inventory': {
+                'au1': [
+                  'sportsillustrated.192.168.1.9.xip.io'
+                ],
+                'pod': [
+                  '13'
+                ]
+              }
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [
+                  [
+                    728,
+                    90
+                  ]
+                ]
+              }
+            },
+            'adUnitCode': 'ad-42a6e2ce42724767a2288295baa68f98',
+            'transactionId': '5119eb8c-48ef-467a-8ede-eb5862cf70b8',
+            'sizes': [
+              [
+                728,
+                90
+              ]
+            ],
+            'bidId': '46e15874aa78708',
+            'bidderRequestId': '4559774772c7f83',
+            'auctionId': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+            'src': 'client',
+            'bidRequestsCount': 3,
+            'bidderRequestsCount': 3,
+            'bidderWinsCount': 0,
+            'startTime': 1592017351709
+          }
+        ],
+        'bidsReceived': [],
+        'winningBids': [],
+        'timeout': 27000
+      }
+      const adapterConfig = {
+        'provider': 'mavenDistributionAnalyticsAdapter',
+        'options': {
+          'contentItemId': 'tm-fake',
+          'countryCode': 'US',
+          'mavenChannel': 'www.si.com',
+          'pod': '11',
+          'productionDomain': 'www.si.com',
+          'screenSize': 'B',
+          'sampling': 1,
+          'zoneMap': {
+            'ad-42a6e2ce42724767a2288295baa68f98': {
+              'zone': 'fixed_bottom',
+              'index': 0
+            }
+          }
+        }
+      }
+      const actualSummary = summarizeAuctionEnd(args, adapterConfig)
+      const expectedSummary = {
+        'auc': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+        cpms: [0],
+        zoneIndexes: [0],
+        zoneNames: ['fixed_bottom'],
+      }
+      assert.deepEqual(actualSummary, expectedSummary)
+    })
+  });
+  describe('createSendOptionsFromBatch', () => {
+    it('should create batch json', () => {
+      const actual = createSendOptionsFromBatch({
+        auc: 'aaa',
+        cpms: [0.04],
+        zoneIndexes: [3],
+        zoneNames: ['sidebar']
+      })
+      const expected = {batch: '{"auc":"aaa","cpms":[0.04],"zoneIndexes":[3],"zoneNames":["sidebar"]}'}
+      assert.deepEqual(actual, expected)
+    })
+  })
+});


### PR DESCRIPTION
This change adds LiftIgniterAnalyticsAdapter, which sends the CPM from AuctionEnd to LiftIgniter.

It’s sort of based on mavenAnalyticsAdapter (hummingbird). Like mavenAnalyticsAdapter, this adapter waits 1s after the `auctionEnd` event before sending the event to LiftIgniter. Like mavenAnalyticsAdapter, it combines multiple `auctionEnd` events into a single request. (Hopefully we don’t hit the Google Load Balancer’s 16KiB headers + URL limit.) And unlike mavenAnalyticsAdapter, it only sends the auction’s `id` and the ad units’ `code` and `cpm` for now.

Current format:
```
$p('send', 'prebid', {
  batch: JSON.stringify([
    {
      auc: args.auctionId,
      codes: [adUnit.code],  // one per ad unit; can be zipped with cpms
      cpms: [max(bid.cpm)],  // one per ad unit
  ])
})
```

Sample batch:

```
[
  {
    "auc": "17beb41d-d650-40a2-90bf-011e0635012a",
    "codes": [
      "ad-efb258fe6fee427e991a9c7ba76927a9",
      "ad-a05abdb5a6be42b6a1a738c9dc0442c0",
      "ad-b1b93a0e4cda4ed3a52f939ec505ca7c",
      "ad-7e3da3ca8639437e92fff1fae3ad83e7",
      "ad-5d118e9a51e446fda8e37d5a3157109e"
    ],
    "cpms": [
      0,
      0,
      0,
      0,
      0
    ]
  }
]
```

This compares to [mavenAnalyticsAdapter](https://github.com/themaven-net/Prebid.js/blob/stable/modules/mavenAnalyticsAdapter.js) (hummingbird), which has many more fields:
```
\d hummingbird_auction
                               Table "admin.hummingbird_auction"
       Column        |           Type           | Collation | Nullable |        Default        
---------------------+--------------------------+-----------+----------+-----------------------
 auction_id          | character varying(50)    |           | not null | 
 correlator          | bigint                   |           | not null | 
 country_code        | character(2)             |           | not null | 
 maven_channel       | character varying(40)    |           | not null | 
 path                | character varying(2000)  |           | not null | 
 pod                 | smallint                 |           | not null | 
 production_domain   | character varying(40)    |           | not null | 
 screen_size         | character(1)             |           | not null | 
 timeout_period      | integer                  |           | not null | 
 bidder              | character varying(20)    |           | not null | 
 action              | character(1)             |           | not null | 
 cpm_mills           | integer                  |           |          | 
 time_to_respond     | integer                  |           |          | 
 adzone_id           | character varying(50)    |           |          | 
 zone_name           | character varying(20)    |           |          | 
 zone_index          | smallint                 |           |          | 
 datetime            | timestamp with time zone |           | not null | 
 content_item_id     | character varying(32)    |           | not null | ''::character varying
 is_deal             | boolean                  |           |          | 
 deal_id             | character varying(50)    |           |          | 
 conn_effective_type | character varying(20)    |           |          | 
 browser_type        | character varying(20)    |           |          | 
```
