### PR TITLE
ADS-4131 update reporting format

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -354,9 +354,23 @@ export function logError() {
   }
 }
 
+let getTimestamp
+if (window.performance && window.performance.now) {
+  getTimestamp = function getTimestamp() {
+    // truncate any partial millisecond
+    return window.performance.now() | 0
+  }
+} else {
+  const initTime = +new Date()
+  getTimestamp = function getTimestamp() {
+    return new Date() - initTime
+  }
+}
+
 function decorateLog(args, prefix) {
   args = [].slice.call(args);
   prefix && args.unshift(prefix);
+  args.unshift(getTimestamp())
   args.unshift('display: inline-block; color: #fff; background: #3b88c3; padding: 1px 4px; border-radius: 3px;');
   args.unshift('%cPrebid');
   return args;

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -81,7 +81,6 @@ describe('MavenDistributionAnalyticsAdapter', function () {
       assert.equal(liftIgniterWrapper.checkIsLoaded(), true)
     })
     it('should work with LiftIgniter already loaded (synchronous $p(onload))', () => {
-      console.log('should work with LiftIgniter already loaded (synchronous $p(onload))')
       defineDollarPReal()
       const liftIgniterWrapper = new testables.LiftIgniterWrapper()
       assert.equal(liftIgniterWrapper._state, 'loaded')

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -1,8 +1,93 @@
-import { createSendOptionsFromBatch, summarizeAuctionEnd } from '../../../modules/mavenDistributionAnalyticsAdapter.js';
+import { createSendOptionsFromBatch, summarizeAuctionEnd, testables } from '../../../modules/mavenDistributionAnalyticsAdapter.js';
 
 var assert = require('assert');
 
 describe('MavenDistributionAnalyticsAdapter', function () {
+  describe('LiftIgniterWrapper', () => {
+    let addEventListener, removeEventListener
+    const domContentLoadListeners = []
+    const que = []
+    beforeEach(() => {
+      window.$p = null
+      addEventListener = sinon.stub(document, 'addEventListener').callsFake((type, fn) => {
+        if (type !== 'DOMContentLoaded') {
+          throw Error(`Unsupported type for stub; expected DOMContentLoaded; got ${type}`)
+        }
+        domContentLoadListeners.push(fn)
+      });
+      removeEventListener = sinon.stub(document, 'removeEventListener').callsFake((type, fn) => {
+        if (type !== 'DOMContentLoaded') {
+          throw Error(`Unsupported type for stub; expected DOMContentLoaded; got ${type}`)
+        }
+        for (let i = domContentLoadListeners.length; i-- > 0;) {
+          if (domContentLoadListeners[i] === fn) {
+            domContentLoadListeners.splice(i, 1)
+          }
+        }
+      });
+    })
+    afterEach(() => {
+      addEventListener.restore()
+      removeEventListener.restore()
+      domContentLoadListeners.length = 0
+      window.$p = null
+      que.length = 0
+    })
+    function defineDollarPStub() {
+      window.$p = (...args) => que.push(args)
+    }
+    function defineDollarPReal() {
+      window.$p = (name, arg) => {
+        if (name !== 'onload') {
+          throw new Error(`Only onload is supported`)
+        }
+        arg()
+      }
+      for (let i = 0; i < que.length; i++) {
+        window.$p.apply(window, que[i])
+      }
+      que.length = 0
+    }
+    it('should check for existence of $p and $p(onload) each time checkIsLoaded is called', () => {
+      const liftIgniterWrapper = new testables.LiftIgniterWrapper()
+      assert.equal(liftIgniterWrapper.checkIsLoaded(), false)
+      assert.equal(liftIgniterWrapper._state, 'wait-for-$p-to-be-defined')
+      defineDollarPStub()
+      assert.equal(liftIgniterWrapper.checkIsLoaded(), false)
+      assert.equal(liftIgniterWrapper._state, 'waiting-$p(\'onload\')')
+      assert.equal(que.length, 1)
+      const [firstCommand, cb] = que[0]
+      assert.equal(firstCommand, 'onload')
+      cb()
+      assert.equal(liftIgniterWrapper._state, 'loaded')
+      assert.equal(liftIgniterWrapper.checkIsLoaded(), true)
+    })
+    it('should check $p and $p(onload) when there is a DOMContentLoad event', () => {
+      assert.equal(window.$p, null)
+      const liftIgniterWrapper = new testables.LiftIgniterWrapper()
+      const listener = domContentLoadListeners[0]
+      assert.notEqual(listener, null)
+      assert.equal(liftIgniterWrapper._state, 'wait-for-$p-to-be-defined')
+      defineDollarPStub()
+
+      listener()
+      assert.equal(liftIgniterWrapper._state, 'waiting-$p(\'onload\')')
+      assert.equal(que.length, 1)
+      assert.equal(domContentLoadListeners.length, 0, 'should removeListener after $p is defined')
+      const [firstCommand, cb] = que[0]
+      assert.equal(firstCommand, 'onload')
+      cb()
+      assert.equal(liftIgniterWrapper._state, 'loaded')
+      assert.equal(liftIgniterWrapper.checkIsLoaded(), true)
+    })
+    it('should work with LiftIgniter already loaded (synchronous $p(onload))', () => {
+      console.log('should work with LiftIgniter already loaded (synchronous $p(onload))')
+      defineDollarPReal()
+      const liftIgniterWrapper = new testables.LiftIgniterWrapper()
+      assert.equal(liftIgniterWrapper._state, 'loaded')
+      assert.equal(liftIgniterWrapper.checkIsLoaded(), true)
+    })
+  })
   describe('summarizeAuctionEnd', function () {
     it('should summarize', () => {
       const args = {

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -879,7 +879,7 @@ describe('MavenDistributionAnalyticsAdapter', function () {
       const actualSummary = summarizeAuctionEnd(args, adapterConfig)
       const expectedSummary = {
         'auc': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
-        cpms: [0],
+        cpmms: [0],
         zoneIndexes: [0],
         zoneNames: ['fixed_bottom'],
       }
@@ -2259,7 +2259,7 @@ describe('MavenDistributionAnalyticsAdapter', function () {
       const actual = summarizeAuctionEnd(mavenArgs, adapterConfig)
       const expected = {
         auc: 'd01409e4-580d-4107-8d92-3c5dec19b41a',
-        cpms: [ 2.604162 ],
+        cpmms: [ 2604 ],
         codes: [ 'gpt-slot-channel-banner-top' ],
       }
       assert.deepEqual(actual, expected)
@@ -2267,13 +2267,16 @@ describe('MavenDistributionAnalyticsAdapter', function () {
   });
   describe('createSendOptionsFromBatch', () => {
     it('should create batch json', () => {
-      const actual = createSendOptionsFromBatch({
+      const actual = createSendOptionsFromBatch([{
         auc: 'aaa',
-        cpms: [0.04],
+        cpmms: [40],
         zoneIndexes: [3],
         zoneNames: ['sidebar']
-      })
-      const expected = {batch: '{"auc":"aaa","cpms":[0.04],"zoneIndexes":[3],"zoneNames":["sidebar"]}'}
+      }])
+      const expected = {
+        batch: '[{"auc":"aaa","cpmms":[40],"zoneIndexes":[3],"zoneNames":["sidebar"]}]',
+        price: 40,
+      }
       assert.deepEqual(actual, expected)
     })
   })


### PR DESCRIPTION
More follow-up to [ADS-4131](https://mavencorp.atlassian.net/browse/ADS-4131)

Discard events if LiftIgniter’s `$p` fails to load, rather than queuing forever. Instead of polling for `$p` every second, listen for the `DOMContentLoaded` event, since if `$p` is loaded, it should be defined in an embedded script. This will allow us to roll out to all of tempest-phoenix since LiftIgniter is not always loaded (particularly on children’s websites). And it prevents the memory leak when LiftIgniter fails to load due to a network error too. If $p does not load, then old bids are discarded once there are more than 32 bids.

Modify the batch format further per @partha0solapurkar and @vipulnaik’s specifications: report bids in `cpmms` as rounded price per million impressions rather than `cpms` price per thousand, and also include a `price` field that totals all the bids within the past second.

Make `MavenDistributionAnalyticsAdapter` `logInfo` its actions for debugging. Include the timestamp with `logInfo`, `logWarn`, and `logError` when `?pbjs_debug=true` per @vipulnaik’s request