### PR TITLE
PA-1596 mavenDistributionAnalyticsAdapter: Add auctionInit event

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -30,10 +30,12 @@ const MAX_BATCH_SIZE_PER_EVENT_TYPE = 32
 
 /**
  * import {AUCTION_STARTED, AUCTION_IN_PROGRESS, AUCTION_COMPLETED} from '../src/auction';
+ * note: timestamp is _auctionStart in src/auction.js
+ * and auctionEnd is _auctionEnd in src/auction.js
  * @typedef {{
  *   auctionId: string
- *   timestamp: Date
- *   auctionEnd: Date
+ *   timestamp: number
+ *   auctionEnd: number
  *   auctionStatus: typeof AUCTION_STARTED | typeof AUCTION_IN_PROGRESS | typeof AUCTION_COMPLETED
  *   adUnits: any[]
  *   adUnitCodes: any[]
@@ -124,6 +126,9 @@ export function summarizeAuctionEnd(args, adapterConfig) {
   })
   const cpmms = args.adUnits.map(adUnit => cpmmsMap[adUnit.code])
   eventToSend.cpmms = cpmms
+  // args.timestamp is only the _auctionStart in src/auction.js
+  // so to get the time for this event we want args.auctionEnd
+  eventToSend.ts = args.auctionEnd
   return eventToSend
 }
 

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -15,7 +15,7 @@ const BATCH_MESSAGE_FREQUENCY = 1000; // Send results batched on a 1s delay
 
 const PROVIDER_CODE = 'mavenDistributionAnalyticsAdapter'
 const MAVEN_DISTRIBUTION_GLOBAL = '$p'
-const MAX_BATCH_SIZE = 32
+const MAX_BATCH_SIZE_PER_EVENT_TYPE = 32
 
 /**
  * We may add more fields in the future
@@ -242,7 +242,7 @@ MavenDistributionAnalyticsAdapterInner.prototype = {
   _sendBatch() {
     this.timeout = null
     Object.keys(this.batch).forEach(eventType => {
-      const countToDiscard = this.batch[eventType].length - MAX_BATCH_SIZE
+      const countToDiscard = this.batch[eventType].length - MAX_BATCH_SIZE_PER_EVENT_TYPE
       if (countToDiscard > 0) {
         logWarn(`$p: Discarding ${countToDiscard} old ${eventType}s`)
         this.batch[eventType].splice(0, countToDiscard)

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -8,6 +8,7 @@ import { logError, logInfo, logWarn } from '../src/utils.js';
 
 // Standard Analytics Adapter code
 const AUCTION_END = CONSTANTS.EVENTS.AUCTION_END
+const AUCTION_INIT = CONSTANTS.EVENTS.AUCTION_INIT
 
 // Internal controls
 const BATCH_MESSAGE_FREQUENCY = 1000; // Send results batched on a 1s delay
@@ -49,10 +50,10 @@ const MAX_BATCH_SIZE = 32
  * // cpmms, zoneIndexes, and zoneNames all have the same length
  * @typedef {{
  *   auc: string
- *   cpmms: number[]
- *   zoneIndexes: number[]
- *   zoneNames: string[]
- * }} AuctionEndSummary
+ *   codes?: string[]
+ *   zoneIndexes?: number[]
+ *   zoneNames?: string[]
+ * }} AuctionInitSummary
  */
 
 /**
@@ -60,9 +61,7 @@ const MAX_BATCH_SIZE = 32
  * @param {MavenDistributionAdapterConfig} adapterConfig
  * @return {AuctionEndSummary}
  */
-export function summarizeAuctionEnd(args, adapterConfig) {
-  /** @type {{[code: string]: number}} */
-  const cpmmsMap = {}
+export function summarizeAuctionInit(args, adapterConfig) {
   const zoneNames = []
   const zoneIndexes = []
   const adUnitCodes = []
@@ -71,7 +70,6 @@ export function summarizeAuctionEnd(args, adapterConfig) {
   let someZoneNameNonNull = false
   let allZoneNamesNonNull = true
   args.adUnits.forEach(adUnit => {
-    cpmmsMap[adUnit.code] = 0
     adUnitCodes.push(adUnit.code)
 
     const zoneConfig = zoneMap[adUnit.code] || {}
@@ -85,15 +83,10 @@ export function summarizeAuctionEnd(args, adapterConfig) {
     someZoneNameNonNull = someZoneNameNonNull || zoneNameNonNull
     allZoneNamesNonNull = allZoneNamesNonNull && zoneNameNonNull
   })
-  args.bidsReceived.forEach(bid => {
-    cpmmsMap[bid.adUnitCode] = Math.max(cpmmsMap[bid.adUnitCode], Math.round(bid.cpm * 1000 || 0))
-  })
-  const cpmms = args.adUnits.map(adUnit => cpmmsMap[adUnit.code])
 
   /** @type {AuctionEndSummary} */
   const eventToSend = {
     auc: args.auctionId,
-    cpmms: cpmms,
   }
   if (!allZoneNamesNonNull) eventToSend.codes = adUnitCodes
   if (someZoneNameNonNull) eventToSend.zoneNames = zoneNames
@@ -102,17 +95,53 @@ export function summarizeAuctionEnd(args, adapterConfig) {
 }
 
 /**
+ * // cpmms, zoneIndexes, and zoneNames all have the same length
+ * @typedef {{
+ *   auc: string
+ *   cpmms: number[]
+ *   codes?: string[]
+ *   zoneIndexes?: number[]
+ *   zoneNames?: string[]
+ * }} AuctionEndSummary
+ */
+
+/**
+ * @param {AuctionEventArgs} args
+ * @param {MavenDistributionAdapterConfig} adapterConfig
+ * @return {AuctionEndSummary}
+ */
+export function summarizeAuctionEnd(args, adapterConfig) {
+  /** @type {{[code: string]: number}} */
+  const cpmmsMap = {}
+  /** @type {AuctionEndSummary} */
+  const eventToSend = summarizeAuctionInit(args, adapterConfig)
+  args.adUnits.forEach(adUnit => {
+    cpmmsMap[adUnit.code] = 0
+  })
+  args.bidsReceived.forEach(bid => {
+    cpmmsMap[bid.adUnitCode] = Math.max(cpmmsMap[bid.adUnitCode], Math.round(bid.cpm * 1000 || 0))
+  })
+  const cpmms = args.adUnits.map(adUnit => cpmmsMap[adUnit.code])
+  eventToSend.cpmms = cpmms
+  return eventToSend
+}
+
+/**
  * Price is in microdollars
- * @param {AuctionEndSummary[]} batch
- * @return {{batch: string, price: number}}
+ * @param {{auctionInit: AuctionInitSummary[], auctionEnd: AuctionEndSummary[]}} batch
+ * @return {{auctionInit?: string, auctionEnd?: string, price: number}}
  */
 export function createSendOptionsFromBatch(batch) {
-  const batchJson = JSON.stringify(batch)
-  let price = 0
-  batch.forEach(auctionEndSummary => {
-    auctionEndSummary.cpmms.forEach(cpmm => price += cpmm)
+  const price = batch[AUCTION_END]?.reduce(
+    (sum, auctionEndSummary) =>
+      sum + auctionEndSummary.cpmms.reduce((sum, cpmm) => sum + cpmm, 0),
+    0
+  )
+  const result = { price: price }
+  Object.keys(batch).forEach(eventType => {
+    result[eventType] = JSON.stringify(batch[eventType])
   })
-  return { batch: batchJson, price: price }
+  return result
 }
 
 const STATE_DOM_CONTENT_LOADING = 'wait-for-$p-to-be-defined'
@@ -173,13 +202,13 @@ LiftIgniterWrapper.prototype = {
 
 /**
  * @param {MavenDistributionAdapterConfig} adapterConfig
- * @property {object[] | null} batch
+ * @property { | null} batch
  * @property {number | null} batchTimeout
  * @property {MavenDistributionAdapterConfig} adapterConfig
  * @property {LiftIgniterWrapper} liftIgniterWrapper
  */
 function MavenDistributionAnalyticsAdapterInner(adapterConfig, liftIgniterWrapper) {
-  this.batch = []
+  this.batch = {}
   this.batchTimeout = null
   this.adapterConfig = adapterConfig
   this.liftIgniterWrapper = liftIgniterWrapper
@@ -190,13 +219,20 @@ MavenDistributionAnalyticsAdapterInner.prototype = {
    */
   track(typeAndArgs) {
     const {eventType, args} = typeAndArgs
-    if (eventType === AUCTION_END) {
-      const eventToSend = summarizeAuctionEnd(args, this.adapterConfig)
+    let eventToSend
+    if (eventType === AUCTION_INIT) {
+      eventToSend = summarizeAuctionInit(args, this.adapterConfig)
+    } else if (eventType === AUCTION_END) {
+      eventToSend = summarizeAuctionEnd(args, this.adapterConfig)
+    }
+    if (eventToSend !== undefined) {
+      this.batch[eventType] ||= []
+      this.batch[eventType].push(eventToSend)
       if (this.timeout == null) {
         this.timeout = setTimeout(this._sendBatch.bind(this), BATCH_MESSAGE_FREQUENCY)
-        logInfo(`$p: added auctionEnd to new batch`)
+        logInfo(`$p: added ${eventType} to new batch`)
       } else {
-        logInfo(`$p: added auctionEnd to existing batch`)
+        logInfo(`$p: added ${eventType} to existing batch`)
       }
       this.batch.push(eventToSend)
     }
@@ -204,16 +240,19 @@ MavenDistributionAnalyticsAdapterInner.prototype = {
 
   _sendBatch() {
     this.timeout = null
-    const countToDiscard = this.batch.length - MAX_BATCH_SIZE
-    if (countToDiscard > 0) {
-      logWarn(`$p: Discarding ${countToDiscard} old items`)
-      this.batch.splice(0, countToDiscard)
-    }
+    Object.keys(this.batch).forEach(eventType => {
+      const countToDiscard = this.batch[eventType].length - MAX_BATCH_SIZE
+      if (countToDiscard > 0) {
+        logWarn(`$p: Discarding ${countToDiscard} old ${eventType}s`)
+        this.batch[eventType].splice(0, countToDiscard)
+      }
+    })
     if (this.liftIgniterWrapper.checkIsLoaded()) {
-      logInfo(`$p: Sending ${this.batch.length} items`)
+      const countsString = Object.keys(this.batch).map(eventType => `${this.batch[eventType].length} ${eventType}s`).join(', ')
+      logInfo(`$p: Sending ${countsString}`)
       const sendOptions = createSendOptionsFromBatch(this.batch)
       this.liftIgniterWrapper.sendPrebid(sendOptions)
-      this.batch.length = 0
+      this.batch = {}
     }
   },
 }

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -87,6 +87,7 @@ export function summarizeAuctionInit(args, adapterConfig) {
   /** @type {AuctionEndSummary} */
   const eventToSend = {
     auc: args.auctionId,
+    ts: args.timestamp,
   }
   if (!allZoneNamesNonNull) eventToSend.codes = adUnitCodes
   if (someZoneNameNonNull) eventToSend.zoneNames = zoneNames

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -879,6 +879,7 @@ describe('MavenDistributionAnalyticsAdapter', function () {
       const actualSummary = summarizeAuctionEnd(args, adapterConfig)
       const expectedSummary = {
         'auc': 'e0a2febe-dc05-4999-87ed-4c40022b6796',
+        ts: 1592017351705,
         cpmms: [0],
         zoneIndexes: [0],
         zoneNames: ['fixed_bottom'],
@@ -2259,6 +2260,7 @@ describe('MavenDistributionAnalyticsAdapter', function () {
       const actual = summarizeAuctionEnd(mavenArgs, adapterConfig)
       const expected = {
         auc: 'd01409e4-580d-4107-8d92-3c5dec19b41a',
+        ts: 1592938047397,
         cpmms: [ 2604 ],
         codes: [ 'gpt-slot-channel-banner-top' ],
       }

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_spec.js
@@ -2266,15 +2266,27 @@ describe('MavenDistributionAnalyticsAdapter', function () {
     })
   });
   describe('createSendOptionsFromBatch', () => {
-    it('should create batch json', () => {
-      const actual = createSendOptionsFromBatch([{
+    it('should create auctionInit batch json', () => {
+      const actual = createSendOptionsFromBatch({auctionInit: [{
+        auc: 'aaa',
+        zoneIndexes: [3],
+        zoneNames: ['sidebar']
+      }]})
+      const expected = {
+        auctionInit: '[{"auc":"aaa","zoneIndexes":[3],"zoneNames":["sidebar"]}]',
+        price: undefined,
+      }
+      assert.deepEqual(actual, expected)
+    })
+    it('should create auctionEnd batch json', () => {
+      const actual = createSendOptionsFromBatch({auctionEnd: [{
         auc: 'aaa',
         cpmms: [40],
         zoneIndexes: [3],
         zoneNames: ['sidebar']
-      }])
+      }]})
       const expected = {
-        batch: '[{"auc":"aaa","cpmms":[40],"zoneIndexes":[3],"zoneNames":["sidebar"]}]',
+        auctionEnd: '[{"auc":"aaa","cpmms":[40],"zoneIndexes":[3],"zoneNames":["sidebar"]}]',
         price: 40,
       }
       assert.deepEqual(actual, expected)

--- a/updatePrebid.js
+++ b/updatePrebid.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Node script for doing the following:
 // 1. git checkout stable branch
 // 2. git pull
@@ -23,7 +24,7 @@
  * $ node updatePrebid.js --modules=modules.json --out=../my/lovely/path/prebid.js
  */
 const { execSync, spawnSync } = require('child_process');
-const fs = require("fs");
+const fs = require('fs');
 
 const argv = require('minimist')(process.argv.slice(2)); // cmd line args
 const validArgs = ['modules', 'out', 'tempest', 'hubpages', 'salish'];
@@ -99,7 +100,7 @@ const main = () => {
   } else {
     if (argv.tempest) {
       checkOutPath(tempestRepo);
-  
+
       buildPrebid(`${tempestRepo}/htdocs/js/prebid/modules.json`);
       copyPrebidToRepos(`${tempestRepo}/htdocs/js/prebid/prebid.min.js`);
       buildPrebid(`${tempestRepo}/htdocs/js/prebid/modules-next.json`);
@@ -111,7 +112,7 @@ const main = () => {
 
       const date = new Date();
       const dateFileStr = date.toJSON().split('T')[0];
-      out = `${salishRepo}/static/cdn/js/prebid-${dateFileStr}.js`;
+      const out = `${salishRepo}/static/cdn/js/prebid-${dateFileStr}.js`;
       copyPrebidToRepos(out);
     }
     if (argv.hubpages) {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Currently we report the `auctionEnd` event to LiftIgniter with the mavenDistributionAnalyticsAdapter. We also want to report the `auctionInit` event, which basically contains a subset of the same fields as the `auctionEnd` except that it tells us what timestamp it happened.

Add the ts field which is the event timestamp.

Change the event sent to LiftIgniter. Instead of batch=json array, send auctionInit=json array and actionEnd=json array.
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

https://mavencorp.atlassian.net/browse/PA-1596