### PR TITLE
Include tspl (time since page load) and tspl_q (time since page load for queueing) for prebid activities sent to LiftIgniter (MAC-586)

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -90,6 +90,8 @@ export function summarizeAuctionInit(args, adapterConfig) {
   const eventToSend = {
     auc: args.auctionId,
     ts: args.timestamp,
+    tspl: args.timestamp - (Date.now() - (window.performance.now() | 0)),
+    tspl_q: window.performance.now() | 0,
   }
   if (!allZoneNamesNonNull) eventToSend.codes = adUnitCodes
   if (someZoneNameNonNull) eventToSend.zoneNames = zoneNames
@@ -129,6 +131,8 @@ export function summarizeAuctionEnd(args, adapterConfig) {
   // args.timestamp is only the _auctionStart in src/auction.js
   // so to get the time for this event we want args.auctionEnd
   eventToSend.ts = args.auctionEnd
+  eventToSend.tspl = args.auctionEnd - (Date.now() - (window.performance.now() | 0))
+  eventToSend.tspl_q = window.performance.now() | 0
   return eventToSend
 }
 


### PR DESCRIPTION
This is part of work on [MAC-586](https://mavencorp.atlassian.net/browse/MAC-586), specifically covering the prebid part. It includes `tspl` (time since page load) and `tspl_q` (time since page load for queueing) fields within the individual entries for `auctionInit` and `auctionEnd`. In the language of https://mavencorp.atlassian.net/browse/MAC-586?focusedCommentId=1599326 this facilitates the collection of B, C, D, and E.

I tested this by building and putting in my local Phoenix using the instructions described in https://github.com/themaven-net/tempest-phoenix/blob/master/htdocs/js/prebid/README.md (albeit not from the `stable` branch but from my local Prebid.js branch I'm PRing from, and into my local branch of Phoenix). See screenshot (also extracted as an object) below:

<img width="1437" alt="Screenshot 2023-03-07 at 8 54 13 PM" src="https://user-images.githubusercontent.com/7758551/223623020-48fc5690-fdda-4e3c-915f-948de744e7a4.png">

Mapping the screenshot to the language of https://mavencorp.atlassian.net/browse/MAC-586?focusedCommentId=1599326:

* B = 13051; it is the `tspl` value for the `auctionInit` key
* C = 13597; it is the `tspl_q` value for the `auctionInit` key
* D = 13743; it is the `tspl` value for the `auctionEnd` key
* E = 13885; it is the `tspl_q` value for the `auctionEnd` key
* G = 14605; it is the `tspl` value for the activity itself (not part of the `auctionInit` or `auctionEnd` arrays); F is also approximately equal to this but we don't capture it separately)

Things to check:

* `ts - tspl` within auctionInit, within auctionEnd, and for the activity itself (using the `ts` and `tspl` sent in the activity) all match up, up to rounding errors of ~1 ms. For the example shown in the screenshot above, the value is ~1678250724585. This is an estimate of page load start time.
* B < C
* C < D
* D < E
* E < G
* G - C (which is approximately F - C; we don't capture F separately) is a little over 1000, that corresponds to the 1-second batching interval

NOTE: The fact that B is so high is a result of us doing local testing causing various things to be slow; I don't fully understand the mechanism that slows things down in local testing, but it doesn't affect the correctness of this PR.

[MAC-586]: https://mavencorp.atlassian.net/browse/MAC-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ