### PR TITLE
Retry sending prebid activity if LiftIgniter JS has not loaded (MAC-598)

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -262,6 +262,9 @@ MavenDistributionAnalyticsAdapterInner.prototype = {
       const sendOptions = createSendOptionsFromBatch(this.batch)
       this.liftIgniterWrapper.sendPrebid(sendOptions)
       this.batch = {}
+    } else if (this.timeout == null) {
+      this.timeout = setTimeout(this._sendBatch.bind(this), BATCH_MESSAGE_FREQUENCY);
+      logInfo(`$p: LiftIgniter not loaded during run of _sendBatch; will retry after ${BATCH_MESSAGE_FREQUENCY}ms`);
     }
   },
 }


### PR DESCRIPTION
This is for [MAC-598](https://mavencorp.atlassian.net/browse/MAC-598).

See the issue description for more context regarding the problem we are trying to solve.

Similar to what I did for the corresponding pubads change (themaven-net/tempest-phoenix#3863) I tested that normal activity sending proceeds as expected, and I separately tested that the retry process works. My testing was as follows:

* I blocked the LiftIgniter JS request url in the network panel, in order to force retries of the event sending, and then loaded a Phoenix page that shows ads.
* I added `?pbjs_debug=true` on the url to activate Prebid.js logging (my speciifc url was http://sportsillustrated.localhost:9001/?pbjs_debug=true).

What I saw in the browser console matched my expectations, so I think this is working well:

<img width="1436" alt="Screenshot 2023-03-15 at 2 35 37 PM" src="https://user-images.githubusercontent.com/7758551/225450811-84408efd-bd83-45b4-8ce6-a7c2fdde622c.png">


[MAC-598]: https://mavencorp.atlassian.net/browse/MAC-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ