### PR TITLE
Switch stringification to be done on array elements rather than on the array itself

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -157,7 +157,7 @@ export function createSendOptionsFromBatch(batch) {
   )
   const result = { price: price }
   Object.keys(batch).forEach(eventType => {
-    result[eventType] = JSON.stringify(batch[eventType])
+    result[eventType] = batch[eventType].map(JSON.stringify)
   })
   return result
 }


### PR DESCRIPTION
This works better for POST activity-sending on the LIftIgniter side. The current default method of activity-sending (GET) is unaffected.

Confirmation that this works with both the GET and POST method; for this I built prebid and copied them to Phoenix, per https://github.com/themaven-net/tempest-phoenix/blob/master/htdocs/js/prebid/README.md; however, I had to remove `aolBidAdapter` as it was giving trouble with the gulp build process. I didn't commit those changes to Phoenix but used them when local testing.

GET:

<img width="882" alt="Screenshot 2023-09-22 at 9 17 10 PM" src="https://github.com/themaven-net/Prebid.js/assets/7758551/51d11a47-3648-46e4-a808-8473a494fb4d">

POST -- note how the values of `auctionEnd` and `auctionInit` are properly formatted arrays:

<img width="883" alt="Screenshot 2023-09-22 at 9 19 50 PM" src="https://github.com/themaven-net/Prebid.js/assets/7758551/99fa0e7a-115a-44e8-a19e-1e7ebfd753e1">

Contrast with POST on the current version of Phoenix master (that is built using the stable version of this repo), where the values of `auctionInit` and `auctionEnd` are stringified arrays:

<img width="1172" alt="Screenshot 2023-09-22 at 9 36 17 PM" src="https://github.com/themaven-net/Prebid.js/assets/7758551/a9dabc47-e85c-45fa-b40d-d84e77973a3c">

