### PR TITLE
Make followup typescript fixes to #49

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -157,7 +157,7 @@ export function createSendOptionsFromBatch(batch) {
   )
   const result = { price: price }
   Object.keys(batch).forEach(eventType => {
-    result[eventType] = batch[eventType].map(JSON.stringify)
+    result[eventType] = (batch[eventType] || []).map((x) => JSON.stringify(x))
   })
   return result
 }


### PR DESCRIPTION
These fixes should be a no-op; they are being made for parity with another private repo (that has typescript checks activated) where these fixes were needed for similar code.

Verification that activity-sending works as expected (see the `auctionInit` and `auctionEnd` near the bottom of the screenshot):

<img width="1186" alt="Screenshot 2023-11-07 at 7 43 08 AM" src="https://github.com/themaven-net/Prebid.js/assets/7758551/5030bd46-7111-41b8-8c43-2a3805f4caa6">
