### PR TITLE
ADS-5929: Track adindex from ad unit (#53)

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.md
+++ b/modules/mavenDistributionAnalyticsAdapter.md
@@ -8,18 +8,3 @@ Maintainer: yonathan.randolph@maven.io
 
 Reports ad bids to MavenDistribution (aka Petametrics or LiftIgniter).
 
-# Configuration
-
-`zoneMap` is expected to be a map of `adUnit.code` to `{index, zone}`.
-
-```
-pbjs.enableAnalytics({
-  provider: 'mavenDistributionAnalyticsAdapter',
-  options: {
-    sampling: 1,
-    zoneMap: {
-      "ad-123456": {"index": 0, "zone": "sidemap"},
-    }
-  },
-});
-```

--- a/test/spec/modules/mavenDistributionAnalyticsAdapter_adUnits.json
+++ b/test/spec/modules/mavenDistributionAnalyticsAdapter_adUnits.json
@@ -1,7541 +1,1117 @@
 [
-  {
-    "code": "ad-f6ff03aa653d41b0a7a0eb2aceddcd93",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-f6ff03aa653d41b0a7a0eb2aceddcd93",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-f6ff03aa653d41b0a7a0eb2aceddcd93"
-        },
-        "tid": "9fdd51eb-b9f7-4c42-bce7-63846dc09b47"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_wNrGBSqcgW"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "header"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_ATF_leaderboard_HDX"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_header_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "header",
-            "index": 0,
-            "adzoneindex": "header_0",
-            "siteadzoneindex": "www.si.com_header_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "authorPageview": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_header_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "header"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "728x90",
-          "cp": 562127,
-          "ct": 736890
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349132,
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "header",
-            "index": 0,
-            "adzoneindex": "header_0",
-            "siteadzoneindex": "www.si.com_header_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "authorPageview": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019825"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            728,
-            90
-          ],
-          [
-            970,
-            90
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        728,
-        90
-      ],
-      [
-        970,
-        90
-      ]
-    ],
-    "transactionId": "9fdd51eb-b9f7-4c42-bce7-63846dc09b47"
-  },
-  {
-    "code": "ad-8929222df13e49feb8b5b4bf35df69b3",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-8929222df13e49feb8b5b4bf35df69b3",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-8929222df13e49feb8b5b4bf35df69b3"
-        },
-        "tid": "24c5d057-2404-4177-a9d4-052126a370cf"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_fixedbottom_leaderboard_HDX"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_fixed_bottom_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "fixed_bottom",
-            "index": 0,
-            "adzoneindex": "fixed_bottom_0",
-            "siteadzoneindex": "www.si.com_fixed_bottom_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_fixed_bottom_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "fixed_bottom"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349273,
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "fixed_bottom",
-            "index": 0,
-            "adzoneindex": "fixed_bottom_0",
-            "siteadzoneindex": "www.si.com_fixed_bottom_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019825"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            728,
-            90
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        728,
-        90
-      ]
-    ],
-    "transactionId": "24c5d057-2404-4177-a9d4-052126a370cf"
-  },
-  {
-    "code": "ad-e47867a131874469a747bc08bfc1e984",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-e47867a131874469a747bc08bfc1e984",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-e47867a131874469a747bc08bfc1e984"
-        },
-        "tid": "6f519655-7dde-4872-93d7-5446cb5e818a"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_qBSKxtb4Cd"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "sidebar"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_rightrail_sticky_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_sidebar_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "sidebar",
-            "index": 0,
-            "adzoneindex": "sidebar_0",
-            "siteadzoneindex": "www.si.com_sidebar_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_sidebar_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "sidebar"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349135,
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "sidebar",
-            "index": 0,
-            "adzoneindex": "sidebar_0",
-            "siteadzoneindex": "www.si.com_sidebar_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ]
-    ],
-    "transactionId": "6f519655-7dde-4872-93d7-5446cb5e818a"
-  },
-  {
-    "code": "ad-536e8410f7974345a83c45fd02bc7c12",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-536e8410f7974345a83c45fd02bc7c12",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-536e8410f7974345a83c45fd02bc7c12"
-        },
-        "tid": "7ac69d62-28f5-4de4-9734-623fbdd7e6a1"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_qBSKxtb4Cd"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "atf_sidebar"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_rightrail_ATF_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_atf_sidebar_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "atf_sidebar",
-            "index": 0,
-            "adzoneindex": "atf_sidebar_0",
-            "siteadzoneindex": "www.si.com_atf_sidebar_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_atf_sidebar_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "atf_sidebar"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349127,
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "atf_sidebar",
-            "index": 0,
-            "adzoneindex": "atf_sidebar_0",
-            "siteadzoneindex": "www.si.com_atf_sidebar_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ]
-    ],
-    "transactionId": "7ac69d62-28f5-4de4-9734-623fbdd7e6a1"
-  },
-  {
-    "code": "ad-b248bc8f8334427484d4abeaba6d5c09",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09"
-        },
-        "tid": "770fe750-9689-43f1-96a1-e8388e38e8e3"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_0"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_0"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "770fe750-9689-43f1-96a1-e8388e38e8e3"
-  },
-  {
-    "code": "ad-b248bc8f8334427484d4abeaba6d5c09",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09"
-        },
-        "tid": "36aa7f78-05e1-4a87-b996-a9d45149c57d"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_0_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+   {
+      "code":"ad-header-879b040b33254cd79ff153cc113af6ac",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#header-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#header-0"
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "36aa7f78-05e1-4a87-b996-a9d45149c57d",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
+         }
       },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-b248bc8f8334427484d4abeaba6d5c09",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-b248bc8f8334427484d4abeaba6d5c09"
-        },
-        "tid": "3f5438a0-4685-4a39-86c7-e20887da4115"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_0_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_0"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "3f5438a0-4685-4a39-86c7-e20887da4115"
-  },
-  {
-    "code": "ad-96901a80108945b6827e977dc2933265",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265"
-        },
-        "tid": "e735e733-2340-44de-a8d8-725106c1a147"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_1"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_1_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_1_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_1"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "e735e733-2340-44de-a8d8-725106c1a147"
-  },
-  {
-    "code": "ad-96901a80108945b6827e977dc2933265",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265"
-        },
-        "tid": "e41ff61f-1196-460a-8461-3e0b760e686a"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_1_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+      "bids":[
+         {
+            "bidder":"rubicon",
+            "params":{
+               "accountId":10348,
+               "siteId":390758,
+               "zoneId":2180002,
+               "inventory":{
+                  "au1":[
+                     "sportsillustrated.localhost"
+                  ],
+                  "au2":[
+                     "sportsillustrated.localhost/college"
+                  ],
+                  "au3":[
+                     "sportsillustrated.localhost/college/2023"
+                  ],
+                  "au4":[
+                     "sportsillustrated.localhost/college/2023/11"
+                  ],
+                  "au5":[
+                     "sportsillustrated.localhost/college/2023/11/20"
+                  ],
+                  "au6":[
+                     "sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly"
+                  ],
+                  "pageOfDay":[
+                     "1"
+                  ],
+                  "pod":[
+                     "1"
+                  ],
+                  "correlator":[
+                     "6594061513583292000"
+                  ]
+               }
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "e41ff61f-1196-460a-8461-3e0b760e686a",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-96901a80108945b6827e977dc2933265",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-96901a80108945b6827e977dc2933265"
-        },
-        "tid": "84e14153-4828-432b-bae9-fdc624592109"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_1_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_1_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_1"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "84e14153-4828-432b-bae9-fdc624592109"
-  },
-  {
-    "code": "ad-bb0c516daca04d0fb392a07716ddb967",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967"
-        },
-        "tid": "ab82166e-6bad-4323-acd1-49fbf07bd93a"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_2"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_2_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_2_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_2"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "ab82166e-6bad-4323-acd1-49fbf07bd93a"
-  },
-  {
-    "code": "ad-bb0c516daca04d0fb392a07716ddb967",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967"
-        },
-        "tid": "9a11920d-2171-45e7-83c8-a7115d20443a"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_2_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"kargo",
+            "params":{
+               "placementId":"_efo8VgJpB1"
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "9a11920d-2171-45e7-83c8-a7115d20443a",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-bb0c516daca04d0fb392a07716ddb967",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-bb0c516daca04d0fb392a07716ddb967"
-        },
-        "tid": "4072c596-eb33-4ab2-89e2-e38449bf637d"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_2_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_2_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_2"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "4072c596-eb33-4ab2-89e2-e38449bf637d"
-  },
-  {
-    "code": "ad-4a3e52bf33d442ada6e6f1c6de40c245",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245"
-        },
-        "tid": "58f96a86-1810-4cb5-a373-65c8d7024e24"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_3"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_3_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_3_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_3"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "58f96a86-1810-4cb5-a373-65c8d7024e24"
-  },
-  {
-    "code": "ad-4a3e52bf33d442ada6e6f1c6de40c245",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245"
-        },
-        "tid": "7cc4da95-10ba-42fc-8526-8a3eb50377d5"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_3_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407970",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "7cc4da95-10ba-42fc-8526-8a3eb50377d5",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-4a3e52bf33d442ada6e6f1c6de40c245",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-4a3e52bf33d442ada6e6f1c6de40c245"
-        },
-        "tid": "e535438c-1118-4631-bd49-f8dca73c9bc8"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_3_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_3_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_3"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "e535438c-1118-4631-bd49-f8dca73c9bc8"
-  },
-  {
-    "code": "ad-d71366a35be34b31b33c33f52eb9ec6a",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a"
-        },
-        "tid": "6bb67838-3434-4b96-961b-8d720787b205"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_4"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_4_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_4_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_4"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "6bb67838-3434-4b96-961b-8d720787b205"
-  },
-  {
-    "code": "ad-d71366a35be34b31b33c33f52eb9ec6a",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a"
-        },
-        "tid": "f5f7d056-a025-4b3b-bc2a-d47ac3abee49"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_4_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_ATF_leaderboard_HDX"
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "f5f7d056-a025-4b3b-bc2a-d47ac3abee49",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-d71366a35be34b31b33c33f52eb9ec6a",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-d71366a35be34b31b33c33f52eb9ec6a"
-        },
-        "tid": "07b9061e-0883-4fd0-bd1e-1b9651a6991d"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_4_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_4_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_4"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "07b9061e-0883-4fd0-bd1e-1b9651a6991d"
-  },
-  {
-    "code": "ad-508707fc999143039bbb574633309f7f",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f"
-        },
-        "tid": "f63d5aec-b5d5-4fbc-8698-33e832bb8890"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_5_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_5_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "f63d5aec-b5d5-4fbc-8698-33e832bb8890"
-  },
-  {
-    "code": "ad-508707fc999143039bbb574633309f7f",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f"
-        },
-        "tid": "68b87ceb-056b-4349-b321-4d7745b26a85"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_5_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_header_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"header",
+                  "index":0,
+                  "adzoneindex":"header_0",
+                  "siteadzoneindex":"www.si.com_header_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "authorPageview":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "68b87ceb-056b-4349-b321-4d7745b26a85",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-508707fc999143039bbb574633309f7f",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-508707fc999143039bbb574633309f7f"
-        },
-        "tid": "d1afccd7-54a4-4514-a67e-cd086f4f6650"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_5_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_5_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "d1afccd7-54a4-4514-a67e-cd086f4f6650"
-  },
-  {
-    "code": "ad-5312768460f54b6f923d97c5a4b05dbd",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd"
-        },
-        "tid": "9906f466-e98c-4534-9432-dd29d579a789"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_6_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_6_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "9906f466-e98c-4534-9432-dd29d579a789"
-  },
-  {
-    "code": "ad-5312768460f54b6f923d97c5a4b05dbd",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd"
-        },
-        "tid": "94bc1e50-bcb4-4d49-8443-050d10ac5382"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_6_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_header_0_dt",
+               "siteId":"801780"
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "94bc1e50-bcb4-4d49-8443-050d10ac5382",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-5312768460f54b6f923d97c5a4b05dbd",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-5312768460f54b6f923d97c5a4b05dbd"
-        },
-        "tid": "f321a582-e185-44b0-bc2d-a0a1ecf7d07c"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_6_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_6_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "f321a582-e185-44b0-bc2d-a0a1ecf7d07c"
-  },
-  {
-    "code": "ad-78258c0367474531b0a0fa62695295de",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de"
-        },
-        "tid": "3299b258-1718-4d89-8868-02a418e00d9b"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_7_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_7_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "3299b258-1718-4d89-8868-02a418e00d9b"
-  },
-  {
-    "code": "ad-78258c0367474531b0a0fa62695295de",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de"
-        },
-        "tid": "af3c47fe-0eb2-4703-8aa1-3bfdd0b62226"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_7_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"pulsepoint",
+            "params":{
+               "bidfloor":0.1,
+               "cf":"728x90",
+               "cp":562127,
+               "ct":736890
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
-      }
-    },
-    "transactionId": "af3c47fe-0eb2-4703-8aa1-3bfdd0b62226",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
-      },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
-      }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
-            },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-78258c0367474531b0a0fa62695295de",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-78258c0367474531b0a0fa62695295de"
-        },
-        "tid": "35183212-461a-404d-a693-0f47ca3adda6"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_7_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_7_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "35183212-461a-404d-a693-0f47ca3adda6"
-  },
-  {
-    "code": "ad-53695f3736b84268a68145a22d0ddab6",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6"
-        },
-        "tid": "679ff027-425f-42c7-93f0-6adce46fc508"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "rubicon",
-        "params": {
-          "accountId": 10348,
-          "siteId": 390758,
-          "zoneId": 2180002,
-          "inventory": {
-            "au1": [
-              "sportsillustrated.192.168.1.50.nip.io"
-            ],
-            "au2": [
-              "sportsillustrated.192.168.1.50.nip.io/college"
-            ],
-            "au3": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022"
-            ],
-            "au4": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12"
-            ],
-            "au5": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04"
-            ],
-            "au6": [
-              "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban"
-            ],
-            "pod": [
-              "8"
-            ],
-            "correlator": [
-              "3506954851143586000"
-            ]
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "kargo",
-        "params": {
-          "placementId": "_aA643Yt2Hq"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "teads",
-        "params": {
-          "placementId": "118766",
-          "pageId": "109250"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "onemobile",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407970",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_incontent_desktop"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_8_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_8_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "pulsepoint",
-        "params": {
-          "bidfloor": 0.1,
-          "cf": "300x250",
-          "cp": 562127,
-          "ct": 736888
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019823"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            300,
-            250
-          ],
-          [
-            728,
-            90
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        300,
-        250
-      ],
-      [
-        728,
-        90
-      ],
-      [
-        1,
-        2
-      ]
-    ],
-    "transactionId": "679ff027-425f-42c7-93f0-6adce46fc508"
-  },
-  {
-    "code": "ad-53695f3736b84268a68145a22d0ddab6",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6"
-        },
-        "tid": "70493913-8cd3-4592-b7e7-4c985c3e0d06"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_8_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
-            ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "native": {
-        "image": {
-          "aspect_ratios": [
-            {
-              "min_height": 400,
-              "min_width": 600,
-              "ratio_height": 2,
-              "ratio_width": 3
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349132,
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"header",
+                  "index":0,
+                  "adzoneindex":"header_0",
+                  "siteadzoneindex":"www.si.com_header_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "authorPageview":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
             }
-          ],
-          "required": true,
-          "sendId": true,
-          "sizes": [
-            600,
-            400
-          ]
-        },
-        "title": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "clickUrl": {
-          "required": true,
-          "sendId": true
-        },
-        "sponsoredBy": {
-          "len": 80,
-          "required": true,
-          "sendId": true
-        },
-        "body": {
-          "required": false,
-          "sendId": true
-        }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"1019825"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  728,
+                  90
+               ],
+               [
+                  970,
+                  90
+               ],
+               [
+                  970,
+                  250
+               ]
+            ]
+         }
+      },
+      "model":{
+         "zone":"header",
+         "index":0
       }
-    },
-    "transactionId": "70493913-8cd3-4592-b7e7-4c985c3e0d06",
-    "nativeParams": {
-      "image": {
-        "aspect_ratios": [
-          {
-            "min_height": 400,
-            "min_width": 600,
-            "ratio_height": 2,
-            "ratio_width": 3
-          }
-        ],
-        "required": true,
-        "sendId": true,
-        "sizes": [
-          600,
-          400
-        ]
+   },
+   {
+      "code":"ad-fixed_bottom-2340e681f9f44549831e8995233b78ac",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#fixed_bottom-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#fixed_bottom-0"
+            }
+         }
       },
-      "title": {
-        "len": 80,
-        "required": true,
-        "sendId": true
+      "bids":[
+         {
+            "bidder":"rubicon",
+            "params":{
+               "accountId":10348,
+               "siteId":390758,
+               "zoneId":2180002,
+               "inventory":{
+                  "au1":[
+                     "sportsillustrated.localhost"
+                  ],
+                  "au2":[
+                     "sportsillustrated.localhost/college"
+                  ],
+                  "au3":[
+                     "sportsillustrated.localhost/college/2023"
+                  ],
+                  "au4":[
+                     "sportsillustrated.localhost/college/2023/11"
+                  ],
+                  "au5":[
+                     "sportsillustrated.localhost/college/2023/11/20"
+                  ],
+                  "au6":[
+                     "sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly"
+                  ],
+                  "pageOfDay":[
+                     "1"
+                  ],
+                  "pod":[
+                     "1"
+                  ],
+                  "correlator":[
+                     "6594061513583292000"
+                  ]
+               }
+            }
+         },
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407970",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
+            }
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_fixedbottom_leaderboard_HDX"
+            }
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_fixed_bottom_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"fixed_bottom",
+                  "index":0,
+                  "adzoneindex":"fixed_bottom_0",
+                  "siteadzoneindex":"www.si.com_fixed_bottom_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_fixed_bottom_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349273,
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"fixed_bottom",
+                  "index":0,
+                  "adzoneindex":"fixed_bottom_0",
+                  "siteadzoneindex":"www.si.com_fixed_bottom_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"1019825"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  728,
+                  90
+               ]
+            ]
+         }
       },
-      "clickUrl": {
-        "required": true,
-        "sendId": true
-      },
-      "sponsoredBy": {
-        "len": 80,
-        "required": true,
-        "sendId": true
-      },
-      "body": {
-        "required": false,
-        "sendId": true
+      "model":{
+         "zone":"fixed_bottom",
+         "index":0
       }
-    },
-    "nativeOrtbRequest": {
-      "ver": "1.2",
-      "assets": [
-        {
-          "id": 0,
-          "required": 1,
-          "img": {
-            "type": 3,
-            "ext": {
-              "aspectratios": [
-                "3:2"
-              ]
+   },
+   {
+      "code":"ad-sidebar-2c655de4c48c4bdf9b48475c548ab029",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#sidebar-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#sidebar-0"
+            }
+         }
+      },
+      "bids":[
+         {
+            "bidder":"rubicon",
+            "params":{
+               "accountId":10348,
+               "siteId":390758,
+               "zoneId":2180002,
+               "inventory":{
+                  "au1":[
+                     "sportsillustrated.localhost"
+                  ],
+                  "au2":[
+                     "sportsillustrated.localhost/college"
+                  ],
+                  "au3":[
+                     "sportsillustrated.localhost/college/2023"
+                  ],
+                  "au4":[
+                     "sportsillustrated.localhost/college/2023/11"
+                  ],
+                  "au5":[
+                     "sportsillustrated.localhost/college/2023/11/20"
+                  ],
+                  "au6":[
+                     "sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly"
+                  ],
+                  "pageOfDay":[
+                     "1"
+                  ],
+                  "pod":[
+                     "1"
+                  ],
+                  "correlator":[
+                     "6594061513583292000"
+                  ]
+               }
+            }
+         },
+         {
+            "bidder":"kargo",
+            "params":{
+               "placementId":"_qBSKxtb4Cd"
+            }
+         },
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407970",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
+            }
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_rightrail_sticky_desktop"
+            }
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_sidebar_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"sidebar",
+                  "index":0,
+                  "adzoneindex":"sidebar_0",
+                  "siteadzoneindex":"www.si.com_sidebar_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_sidebar_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"pulsepoint",
+            "params":{
+               "bidfloor":0.1,
+               "cf":"300x600",
+               "cp":562127,
+               "ct":736889
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349135,
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"sidebar",
+                  "index":0,
+                  "adzoneindex":"sidebar_0",
+                  "siteadzoneindex":"www.si.com_sidebar_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"644739"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  300,
+                  600
+               ],
+               [
+                  300,
+                  250
+               ]
+            ]
+         }
+      },
+      "model":{
+         "zone":"sidebar",
+         "index":0
+      }
+   },
+   {
+      "code":"ad-atf_sidebar-d0df6466853f4fc7aca6a0685c5ed19e",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#atf_sidebar-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#atf_sidebar-0"
+            }
+         }
+      },
+      "bids":[
+         {
+            "bidder":"rubicon",
+            "params":{
+               "accountId":10348,
+               "siteId":390758,
+               "zoneId":2180002,
+               "inventory":{
+                  "au1":[
+                     "sportsillustrated.localhost"
+                  ],
+                  "au2":[
+                     "sportsillustrated.localhost/college"
+                  ],
+                  "au3":[
+                     "sportsillustrated.localhost/college/2023"
+                  ],
+                  "au4":[
+                     "sportsillustrated.localhost/college/2023/11"
+                  ],
+                  "au5":[
+                     "sportsillustrated.localhost/college/2023/11/20"
+                  ],
+                  "au6":[
+                     "sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly"
+                  ],
+                  "pageOfDay":[
+                     "1"
+                  ],
+                  "pod":[
+                     "1"
+                  ],
+                  "correlator":[
+                     "6594061513583292000"
+                  ]
+               }
+            }
+         },
+         {
+            "bidder":"kargo",
+            "params":{
+               "placementId":"_qBSKxtb4Cd"
+            }
+         },
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407970",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
+            }
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_rightrail_ATF_desktop"
+            }
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_atf_sidebar_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"atf_sidebar",
+                  "index":0,
+                  "adzoneindex":"atf_sidebar_0",
+                  "siteadzoneindex":"www.si.com_atf_sidebar_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_atf_sidebar_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"pulsepoint",
+            "params":{
+               "bidfloor":0.1,
+               "cf":"300x600",
+               "cp":562127,
+               "ct":736889
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349127,
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"atf_sidebar",
+                  "index":0,
+                  "adzoneindex":"atf_sidebar_0",
+                  "siteadzoneindex":"www.si.com_atf_sidebar_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"644739"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  300,
+                  600
+               ],
+               [
+                  300,
+                  250
+               ]
+            ]
+         }
+      },
+      "model":{
+         "zone":"atf_sidebar",
+         "index":0
+      }
+   },
+   {
+      "code":"ad-in_content-1b31ec2dd1a14304adc32c5dba44ada2",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#in_content-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#in_content-0"
+            }
+         }
+      },
+      "bids":[
+         {
+            "bidder":"rubicon",
+            "params":{
+               "accountId":10348,
+               "siteId":390758,
+               "zoneId":2180002,
+               "inventory":{
+                  "au1":[
+                     "sportsillustrated.localhost"
+                  ],
+                  "au2":[
+                     "sportsillustrated.localhost/college"
+                  ],
+                  "au3":[
+                     "sportsillustrated.localhost/college/2023"
+                  ],
+                  "au4":[
+                     "sportsillustrated.localhost/college/2023/11"
+                  ],
+                  "au5":[
+                     "sportsillustrated.localhost/college/2023/11/20"
+                  ],
+                  "au6":[
+                     "sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly"
+                  ],
+                  "pageOfDay":[
+                     "1"
+                  ],
+                  "pod":[
+                     "1"
+                  ],
+                  "correlator":[
+                     "6594061513583292000"
+                  ]
+               }
+            }
+         },
+         {
+            "bidder":"kargo",
+            "params":{
+               "placementId":"_aA643Yt2Hq"
+            }
+         },
+         {
+            "bidder":"teads",
+            "params":{
+               "placementId":"118766",
+               "pageId":"109250"
+            }
+         },
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407970",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
+            }
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_incontent_desktop"
+            }
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_in_content_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_in_content_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"pulsepoint",
+            "params":{
+               "bidfloor":0.1,
+               "cf":"300x250",
+               "cp":562127,
+               "ct":736888
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349134,
+               "keywords":{
+                  "cm":"tempest",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"1019823"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  300,
+                  250
+               ],
+               [
+                  728,
+                  90
+               ],
+               [
+                  1,
+                  2
+               ]
+            ]
+         }
+      },
+      "model":{
+         "zone":"in_content",
+         "index":"0"
+      }
+   },
+   {
+      "code":"ad-in_content-1b31ec2dd1a14304adc32c5dba44ada2",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#in_content-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#in_content-0"
+            }
+         }
+      },
+      "bids":[
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_in_content_0_dt",
+               "member":"8186",
+               "video":{
+                  "playback_method":"auto_play_sound_off",
+                  "skippable":false
+               },
+               "keywords":{
+                  "cm":"tempest",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         }
+      ],
+      "mediaTypes":{
+         "native":{
+            "image":{
+               "aspect_ratios":[
+                  {
+                     "min_height":400,
+                     "min_width":600,
+                     "ratio_height":2,
+                     "ratio_width":3
+                  }
+               ],
+               "required":true,
+               "sendId":true,
+               "sizes":[
+                  600,
+                  400
+               ]
             },
-            "w": 600,
-            "h": 400
-          }
-        },
-        {
-          "id": 1,
-          "required": 1,
-          "title": {
-            "len": 80
-          }
-        },
-        {
-          "id": 2,
-          "required": 1,
-          "data": {
-            "type": 1,
-            "len": 80
-          }
-        },
-        {
-          "id": 3,
-          "required": 0,
-          "data": {
-            "type": 2
-          }
-        }
-      ]
-    }
-  },
-  {
-    "code": "ad-53695f3736b84268a68145a22d0ddab6",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-53695f3736b84268a68145a22d0ddab6"
-        },
-        "tid": "568feb03-9b12-4377-bd43-26e563d7a6b5"
+            "title":{
+               "len":80,
+               "required":true,
+               "sendId":true
+            },
+            "clickUrl":{
+               "required":true,
+               "sendId":true
+            },
+            "sponsoredBy":{
+               "len":80,
+               "required":true,
+               "sendId":true
+            },
+            "body":{
+               "required":false,
+               "sendId":true
+            }
+         }
+      },
+      "model":{
+         "zone":"in_content",
+         "index":"0"
       }
-    },
-    "bids": [
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_in_content_8_dt",
-          "member": "8186",
-          "video": {
-            "playback_method": "auto_play_sound_off",
-            "skippable": false
-          },
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
+   },
+   {
+      "code":"ad-in_content-1b31ec2dd1a14304adc32c5dba44ada2",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#in_content-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#in_content-0"
+            }
+         }
+      },
+      "bids":[
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_in_content_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349134,
+               "keywords":{
+                  "cm":"tempest",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         }
+      ],
+      "mediaTypes":{
+         "video":{
+            "api":[
+               1,
+               2
             ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_in_content_8_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "in_content_5"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349134,
-          "keywords": {
-            "cm": "tempest",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
+            "context":"outstream",
+            "mimes":[
+               "application/javascript",
+               "video/mp4",
+               "video/webm"
             ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      }
-    ],
-    "mediaTypes": {
-      "video": {
-        "api": [
-          1,
-          2
-        ],
-        "context": "outstream",
-        "mimes": [
-          "application/javascript",
-          "video/mp4",
-          "video/webm"
-        ],
-        "minduration": 0,
-        "maxduration": 15,
-        "playerSize": [
-          [
-            640,
-            480
-          ]
-        ],
-        "protocols": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        "renderer": {
-          "url": "https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
-        }
-      }
-    },
-    "sizes": [
-      [
-        640,
-        480
-      ]
-    ],
-    "transactionId": "568feb03-9b12-4377-bd43-26e563d7a6b5"
-  },
-  {
-    "code": "ad-9ea4571a29ec4795a95b27f8ac632877",
-    "adUnitPath": "/88059007/www.si.com/college/college-football",
-    "ortb2Imp": {
-      "ext": {
-        "gpid": "/88059007/www.si.com/college/college-football#ad-9ea4571a29ec4795a95b27f8ac632877",
-        "data": {
-          "pbadslot": "/88059007/www.si.com/college/college-football#ad-9ea4571a29ec4795a95b27f8ac632877"
-        },
-        "tid": "080a9bbb-79b9-4e47-b1ee-528499441f90"
-      }
-    },
-    "bids": [
-      {
-        "bidder": "pubmatic",
-        "params": {
-          "adSlot": "4407971",
-          "pmzoneid": "www.si.com",
-          "publisherId": "156229",
-          "dctr": "au1=sportsillustrated.192.168.1.50.nip.io|au2=sportsillustrated.192.168.1.50.nip.io/college|au3=sportsillustrated.192.168.1.50.nip.io/college/2022|au4=sportsillustrated.192.168.1.50.nip.io/college/2022/12|au5=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04|au6=sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban|pod=8|correlator=3506954851143586000"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "triplelift",
-        "params": {
-          "inventoryCode": "SportsIllustratedNational_adhesion"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "appnexus",
-        "params": {
-          "allowSmallerSizes": true,
-          "invCode": "www.si.com_adhesion_0_dt",
-          "member": "8186",
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "adhesion",
-            "index": 0,
-            "adzoneindex": "adhesion_0",
-            "siteadzoneindex": "www.si.com_adhesion_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
+            "minduration":0,
+            "maxduration":15,
+            "playerSize":[
+               640,
+               480
             ],
-            "pagetype": "article",
-            "cv": "sports",
-            "au1": "sportsillustrated.192.168.1.50.nip.io",
-            "au2": "sportsillustrated.192.168.1.50.nip.io/college",
-            "au3": "sportsillustrated.192.168.1.50.nip.io/college/2022",
-            "au4": "sportsillustrated.192.168.1.50.nip.io/college/2022/12",
-            "au5": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04",
-            "au6": "sportsillustrated.192.168.1.50.nip.io/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "pod": 8,
-            "correlator": "3506954851143586000"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "ix",
-        "params": {
-          "id": "www.si.com_adhesion_0_dt",
-          "siteId": "801780"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "yahoossp",
-        "params": {
-          "dcn": "8a969d6501787859e95f5b60441400d4",
-          "pos": "adhesion"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
-      },
-      {
-        "bidder": "grid",
-        "params": {
-          "uid": 349136,
-          "keywords": {
-            "cm": "tempest",
-            "adzone": "adhesion",
-            "index": 0,
-            "adzoneindex": "adhesion_0",
-            "siteadzoneindex": "www.si.com_adhesion_0",
-            "path": "/college/2022/12/04/college-football-playoff-debate-tcu-ohio-state-alabama-saban",
-            "author": "tm-ci025509fe80002580",
-            "terms": [
-              "College",
-              "News And Analysis",
-              "HP Feature",
-              "College Football"
+            "protocols":[
+               1,
+               2,
+               3,
+               4,
+               5,
+               6
             ],
-            "pagetype": "article",
-            "cv": "sports"
-          }
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
+            "placement":3,
+            "plcmt":4,
+            "renderer":{
+               "url":"https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js"
+            }
+         }
       },
-      {
-        "bidder": "33across",
-        "params": {
-          "siteId": "dDAkWSTCqr7iovrkHcnlxd",
-          "productId": "siab"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
+      "model":{
+         "zone":"in_content",
+         "index":"0"
+      }
+   },
+   {
+      "code":"ad-adhesion-69b50a2f41724b9eb44b3dd4e02e3e2b",
+      "adUnitPath":"/88059007/www.si.com/college/college-football",
+      "ortb2Imp":{
+         "ext":{
+            "gpid":"/88059007/www.si.com/college/college-football#adhesion-0",
+            "data":{
+               "pbadslot":"/88059007/www.si.com/college/college-football#adhesion-0"
+            }
+         }
       },
-      {
-        "bidder": "sovrn",
-        "params": {
-          "tagid": "1019825"
-        },
-        "auctionId": "e8bf0c1d-3ae1-4a3a-a408-a938f9776750",
-        "floorData": {
-          "skipped": false,
-          "skipRate": 0,
-          "modelVersion": "Default Ad Unit Floors",
-          "location": "setConfig"
-        },
-        "crumbs": {
-          "pubcid": "de81df13-ea28-456e-9338-d28f6a50ae3e"
-        }
+      "bids":[
+         {
+            "bidder":"pubmatic",
+            "params":{
+               "adSlot":"4407971",
+               "pmzoneid":"www.si.com",
+               "publisherId":"156229",
+               "dctr":"au1=sportsillustrated.localhost|au2=sportsillustrated.localhost/college|au3=sportsillustrated.localhost/college/2023|au4=sportsillustrated.localhost/college/2023/11|au5=sportsillustrated.localhost/college/2023/11/20|au6=sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly|pageOfDay=1|pod=1|correlator=6594061513583292000"
+            }
+         },
+         {
+            "bidder":"triplelift",
+            "params":{
+               "inventoryCode":"SportsIllustratedNational_adhesion"
+            }
+         },
+         {
+            "bidder":"appnexus",
+            "params":{
+               "allowSmallerSizes":true,
+               "invCode":"www.si.com_adhesion_0_dt",
+               "member":"8186",
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"adhesion",
+                  "index":0,
+                  "adzoneindex":"adhesion_0",
+                  "siteadzoneindex":"www.si.com_adhesion_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports",
+                  "au1":"sportsillustrated.localhost",
+                  "au2":"sportsillustrated.localhost/college",
+                  "au3":"sportsillustrated.localhost/college/2023",
+                  "au4":"sportsillustrated.localhost/college/2023/11",
+                  "au5":"sportsillustrated.localhost/college/2023/11/20",
+                  "au6":"sportsillustrated.localhost/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "pageOfDay":1,
+                  "pod":1,
+                  "correlator":"6594061513583292000"
+               }
+            }
+         },
+         {
+            "bidder":"ix",
+            "params":{
+               "id":"www.si.com_adhesion_0_dt",
+               "siteId":"801780"
+            }
+         },
+         {
+            "bidder":"grid",
+            "params":{
+               "uid":349136,
+               "keywords":{
+                  "cm":"tempest",
+                  "adzone":"adhesion",
+                  "index":0,
+                  "adzoneindex":"adhesion_0",
+                  "siteadzoneindex":"www.si.com_adhesion_0",
+                  "path":"www.si.com/college/2023/11/20/jim-harbaugh-michigan-flipped-ohio-state-rivarly",
+                  "author":"tm-ci0251413b90002595",
+                  "terms":[
+                     "HP Feature",
+                     "College Football",
+                     "News And Analysis",
+                     "College"
+                  ],
+                  "pagetype":"article",
+                  "cv":"sports"
+               }
+            }
+         },
+         {
+            "bidder":"sovrn",
+            "params":{
+               "tagid":"1019825"
+            }
+         }
+      ],
+      "mediaTypes":{
+         "banner":{
+            "sizes":[
+               [
+                  1,
+                  1
+               ]
+            ]
+         }
+      },
+      "model":{
+         "zone":"adhesion",
+         "index":0
       }
-    ],
-    "mediaTypes": {
-      "banner": {
-        "sizes": [
-          [
-            1,
-            1
-          ]
-        ]
-      }
-    },
-    "sizes": [
-      [
-        1,
-        1
-      ]
-    ],
-    "transactionId": "080a9bbb-79b9-4e47-b1ee-528499441f90"
-  }
+   }
 ]


### PR DESCRIPTION
Merges adIndex tracking changes from `stable-next` into `stable`.