### PR TITLE
Fallback mechanism for gathering ad zone, index

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -48,8 +48,33 @@ const MAX_BATCH_SIZE_PER_EVENT_TYPE = 32
  * }} AuctionEventArgs
  */
 
-export const getAdIndex = (adUnit) =>
-  adUnit.model ? Number(adUnit.model.index) : null
+const getAdModelProperty = (adUnit, prop) => {
+  // First check the adUnit model property itself, if present.
+  if (adUnit.model) {
+    return adUnit.model[prop];
+  } else if (window.googletag && window.googletag.pubads) {
+    // Fallback to looking at targeting from the GPT ad slot. The
+    // target name will have an 'ad' prefix.
+    const slot = window.googletag.pubads().getSlots().find(slot => slot.getSlotElementId() === adUnit.code);
+    if (slot) {
+      const target = slot.getTargeting('ad' + prop);
+      if (target.length) {
+        return target[0];
+      }
+    }
+  }
+  return null;
+};
+
+export const getAdIndex = (adUnit) => {
+  const idx = getAdModelProperty(adUnit, 'index');
+  if (idx != null) {
+    return Number(idx);
+  }
+  return idx;
+};
+
+const getAdZone = (adUnit) => getAdModelProperty(adUnit, 'zone');
 
 export const filterDuplicateAdUnits = (adUnits) =>
   Array.from(new Map(adUnits.map(adUnit => [
@@ -68,7 +93,7 @@ function getCommonEventToSend(args, adapterConfig) {
 
   args.adUnits.forEach(adUnit => {
     const zoneIndex = getAdIndex(adUnit)
-    const zoneName = adUnit.model?.zone ?? null
+    const zoneName = getAdZone(adUnit);
     const zoneIndexNonNull = zoneIndex != null
     const zoneNameNonNull = zoneName != null
 


### PR DESCRIPTION
In the event that the ad unit does not have a model property with zone and index, we will retrieve these from the GPT slot targeting instead. This is primarily for the Media.net integration which defines the PrebidJS ad units dynamically.
