### PR TITLE
ADS-6194: Updating the floor value calculation

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -151,7 +151,6 @@ function getCommonEventToSend(args, adapterConfig) {
  * @return {AuctionEndSummary}
  */
 export function summarizeAuctionInit(args, adapterConfig) {
-  const floorData = config.getConfig('floors')
   const flattenedBidRequests = args.bidderRequests.reduce((total, curr) => {
     return [...total, ...curr.bids]
   }, [])
@@ -163,19 +162,10 @@ export function summarizeAuctionInit(args, adapterConfig) {
     flattenedBidRequests.forEach(fbr => {
       if (fbr.adUnitCode === adUnit.code) {
         bidders.push(fbr.bidder)
-        // Initiate with the with bid floor value
-        let floor = fbr?.floorData?.floorMin
-        // If value not found and mediaType is banner
-        // Add the default the default banner value from global config
-        if (!floor && fbr?.mediaTypes?.banner) {
-          floor = floorData?.data?.values?.banner
+        let floor = fbr?.getFloor()?.floor ?? null;
+        if (floor) {
+          floor = Math.round((floor || 0) * 1000);
         }
-        // If value not found and mediaType is video
-        // Add the default the default video value from global config
-        if (!floor && fbr?.mediaTypes?.video) {
-          floor = floorData?.data?.values?.video
-        }
-        floor = Math.round((floor || 0) * 1000)
         floors.push(floor)
       }
     })

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -162,7 +162,7 @@ export function summarizeAuctionInit(args, adapterConfig) {
     flattenedBidRequests.forEach(fbr => {
       if (fbr.adUnitCode === adUnit.code) {
         bidders.push(fbr.bidder)
-        let floor = fbr?.getFloor()?.floor ?? null;
+        let floor = fbr?.getFloor?.()?.floor ?? null;
         if (floor) {
           floor = Math.round((floor || 0) * 1000);
         }


### PR DESCRIPTION
Updating the how we calculate the floor value in our `mavenDistributionAnalyticsAdapter.js`.
To validate the new calculations please see the images below:
![StandardFloor](https://github.com/themaven-net/Prebid.js/assets/17586348/4e0f500a-bc52-4104-81d8-9962e8eecca4)
In the standard setup where there are no fine grained control of the floor, we can see that our old floor calculation match up to our new floor calculation. So by default our floor calculations worked. Please refer to the picture and the console log statement below
![Granular Floor](https://github.com/themaven-net/Prebid.js/assets/17586348/ab7f1d2e-e358-4d34-810a-ece29762600a)
In this case, the old floor calculation is not able to calculate the floor price properly and reports a default of zero. This is because in this experiment the floor prices are set using more granular control. As we can see, the new way of calculation correctly calculates them. You can match the adUnitCode with the floor pricing here: `htdocs/bootscripts/adAuction/PrebidJS.js`
