### PR TITLE
Ensure non-null cpmms (to stable)

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -306,7 +306,7 @@ export function summarizeAuctionEnd(args, adapterConfig) {
         bidAmountss.push(bidAmounts)
         bidResponseTimess.push(bidResponseTimes)
         floorss.push(floors)
-        cpmms.push(cpmmsMap[adUnit.code])
+        cpmms.push(cpmmsMap[adUnit.code] ?? 0)
       })
     } else {
       adUnitCodes.push(adUnit.code)
@@ -319,7 +319,7 @@ export function summarizeAuctionEnd(args, adapterConfig) {
       bidAmountss.push(bidAmounts)
       bidResponseTimess.push(bidResponseTimes)
       floorss.push(floors)
-      cpmms.push(cpmmsMap[adUnit.code])
+      cpmms.push(cpmmsMap[adUnit.code] ?? 0)
     }
   })
 


### PR DESCRIPTION
This line used to ensure that cpmms are set to zero if they are absent, but the new code doesn't ensure this: https://github.com/themaven-net/Prebid.js/pull/68/files#diff-284597ae16ac6b2df9754a7ff6d95822d118d85d80425c5171808706899f8f98L244

This has material impact because in the BigQuery tables cpmms are required 

HT @tomonacci for catching this! https://mavencoalition.slack.com/archives/C01DMTP5YHL/p1720451497887079