### PR TITLE
[MAC-1034] make fixes to bid status (stable)

### DIFF
--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -139,7 +139,7 @@ export function summarizeAuctionInit(args, adapterConfig) {
 
   const dateNow = Date.now()
   const windowPerformanceNow = window.performance.now() | 0
-  
+
   /** @type {AuctionEndSummary} */
   const eventToSend = {
     auc: args.auctionId,
@@ -157,49 +157,32 @@ export function summarizeAuctionInit(args, adapterConfig) {
   return eventToSend
 }
 
-const getBidStatusAmtsAndResponseTime = (key, bidRequest, args) => {
+const getBidStatusAmtsAndResponseTime = (statusKey, bidRequest, args) => {
   // Config decribing the various bidStatus, bidAmount and bidResponseTime
   // values for each bid condition
   const BID_STATUS_MAP = {
     bidsRejected: (bid) => ({
       bidStatus: `error: ${bid.rejectionReason || 'generic'}`,
       bidAmount: Math.round((bid.cpm || 0) * 1000),
-      bidResponseTime: bid.timeToRespond || null,
+      bidResponseTime: bid.timeToRespond ?? null,
     }),
-    noBids: () => ({
+    noBids: (bid) => ({
       bidStatus: 'nobid',
       bidAmount: 0,
       bidResponseTime: null,
     }),
-    timeout: () => ({
-      bidStatus: 'timeout',
-      bidAmount: 0,
-      bidResponseTime: args.timeout,
-    }),
-    bid: (bid) => ({
-      bidStatus: 'bid',
+    bidsReceived: (bid) => ({
+      bidStatus: (bid.timeToRespond < args.timeout) ? 'bid' : 'delay',
       bidAmount: Math.round((bid.cpm || 0) * 1000),
       bidResponseTime: bid.timeToRespond,
     })
   }
-  const filteredBids = (args[key] || []).filter((bid) => (
+  const filteredBids = (args[statusKey] || []).filter((bid) => (
     (bid.bidId || bid.requestId) === bidRequest.bidId
   ))
   if (filteredBids?.length > 0) {
     const bid = filteredBids[0]
-    if (key === 'bidsRejected') {
-      return BID_STATUS_MAP[key](bid)
-    }
-    if (key === 'noBids') {
-      return BID_STATUS_MAP[key]()
-    }
-    // Look in bidsRequested and compare with timeout
-    // If bid.timeToRespond > args.timeout then
-    // the bid is considered to be a timed out bid
-    if (bid.timeToRespond < args.timeout) {
-      return BID_STATUS_MAP.bid(bid)
-    }
-    return BID_STATUS_MAP.timeout()
+    return BID_STATUS_MAP[statusKey](bid)
   }
   return false
 }
@@ -235,6 +218,7 @@ export function summarizeAuctionEnd(args, adapterConfig) {
   const bidAmountss = []
   const bidResponseTimess = []
   const floorss = []
+
   const flattenedBidRequests = args.bidderRequests.reduce((total, curr) => {
     return [...total, ...curr.bids]
   }, [])
@@ -266,7 +250,7 @@ export function summarizeAuctionEnd(args, adapterConfig) {
     const bidAmounts = []
     const bidResponseTimes = []
     const floors = []
-    
+
     flattenedBidRequests.forEach(fbr => {
       if (fbr.adUnitCode === adUnit.code) {
         bidders.push(fbr.bidder)
@@ -276,11 +260,10 @@ export function summarizeAuctionEnd(args, adapterConfig) {
         // found we look into the bidsReceived and check whether the responsetime is greater
         // or less than timeout and assign it either a timeout bid or a valid valid
         // The bidsReceived array has both timeout bids and the valid bids
-        const keys = ['bidsRejected', 'noBids', 'bidsReceived']
-        let bidStatus = null; let bidAmount = null; let bidResponseTime = null;
-        for (let i = 0; i < keys.length; i += 1) {
-          const status = keys[i]
-          const data = getBidStatusAmtsAndResponseTime(status, fbr, args)
+        const statusKeys = ['bidsRejected', 'noBids', 'bidsReceived']
+        let bidStatus = 'timeout', bidAmount = 0, bidResponseTime = args.timeout;
+        for (const statusKey of statusKeys) {
+          const data = getBidStatusAmtsAndResponseTime(statusKey, fbr, args)
           if (data) {
             bidStatus = data.bidStatus;
             bidAmount = data.bidAmount;

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -166,13 +166,13 @@ const getBidStatusAmtsAndResponseTime = (statusKey, bidRequest, args) => {
       bidAmount: Math.round((bid.cpm || 0) * 1000),
       bidResponseTime: bid.timeToRespond ?? null,
     }),
-    noBids: (bid) => ({
+    noBids: () => ({
       bidStatus: 'nobid',
       bidAmount: 0,
       bidResponseTime: null,
     }),
     bidsReceived: (bid) => ({
-      bidStatus: ((bid.timeToRespond >= args.timeout) ? 'timeout:' : '') + 'bid',
+      bidStatus: (((bid.timeToRespond ?? 0) >= args.timeout) ? 'timeout:' : '') + 'bid',
       bidAmount: Math.round((bid.cpm || 0) * 1000),
       bidResponseTime: bid.timeToRespond,
     })

--- a/modules/mavenDistributionAnalyticsAdapter.js
+++ b/modules/mavenDistributionAnalyticsAdapter.js
@@ -162,7 +162,7 @@ const getBidStatusAmtsAndResponseTime = (statusKey, bidRequest, args) => {
   // values for each bid condition
   const BID_STATUS_MAP = {
     bidsRejected: (bid) => ({
-      bidStatus: `error: ${bid.rejectionReason || 'generic'}`,
+      bidStatus: (((bid.timeToRespond ?? 0) >= args.timeout) ? 'timeout:' : '') + `error: ${bid.rejectionReason || 'generic'}`,
       bidAmount: Math.round((bid.cpm || 0) * 1000),
       bidResponseTime: bid.timeToRespond ?? null,
     }),
@@ -172,7 +172,7 @@ const getBidStatusAmtsAndResponseTime = (statusKey, bidRequest, args) => {
       bidResponseTime: null,
     }),
     bidsReceived: (bid) => ({
-      bidStatus: (bid.timeToRespond < args.timeout) ? 'bid' : 'delay',
+      bidStatus: ((bid.timeToRespond >= args.timeout) ? 'timeout:' : '') + 'bid',
       bidAmount: Math.round((bid.cpm || 0) * 1000),
       bidResponseTime: bid.timeToRespond,
     })
@@ -261,7 +261,7 @@ export function summarizeAuctionEnd(args, adapterConfig) {
         // or less than timeout and assign it either a timeout bid or a valid valid
         // The bidsReceived array has both timeout bids and the valid bids
         const statusKeys = ['bidsRejected', 'noBids', 'bidsReceived']
-        let bidStatus = 'timeout', bidAmount = 0, bidResponseTime = args.timeout;
+        let bidStatus = 'timeout:missing', bidAmount = 0, bidResponseTime = args.timeout;
         for (const statusKey of statusKeys) {
           const data = getBidStatusAmtsAndResponseTime(statusKey, fbr, args)
           if (data) {


### PR DESCRIPTION
The main change is to change `timeout` to `delay` and the default `null` to `timeout` as that better reflects what's going on. Also includes another minor change from || to ?? and some code simplification. 

This change should help us determine whether we have something to gain by increasing / decreasing the timeout value we use for the first auction, by looking at the relative proportion of bid and delay. 

Local tested using the Fast 3G, Slow 3G and No Throttling settings in the chrome dev tools. Screenshots for Fast 3G, where the local testing saw the most comprehensive range of statuses:

before: there are some nulls under bid_statusss:
<img width="1715" alt="Screenshot 2024-08-07 at 17 39 14" src="https://github.com/user-attachments/assets/ae86c3e9-0f88-4001-b195-c41299743d55">

after: no nulls under bid_statusss:
<img width="1714" alt="Screenshot 2024-08-07 at 17 35 05" src="https://github.com/user-attachments/assets/389158a7-5d41-4fb2-bcfe-bbaadb98527a">